### PR TITLE
Add `/health-checks` endpoint & domain.lisp snippet

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -47,6 +47,10 @@ defmodule Dispatcher do
   # RESOURCES
   ###############
 
+  get "/health-checks/*_path", %{ layer: :resources, accept: %{ json: true } } do
+    forward conn, [], "http://resource/health-checks/"
+  end
+
   get "/catalogs/*path", %{ layer: :resources, accept: %{ json: true } } do
     forward conn, path, "http://cache/catalogs/"
   end

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -14,3 +14,42 @@
 
 (read-domain-file "dcat.json")
 (read-domain-file "besluitvorming.json")
+(read-domain-file "health-check.lisp")
+
+(defcall :get (base-path)
+  (handler-case
+      (progn
+        (verify-json-api-request-accept-header)
+        (list-call (find-resource-by-path base-path)))
+    (no-such-resource ()
+      (respond-not-found))
+    (access-denied (condition)
+      (response-for-access-denied-condition condition))
+    (no-such-link (condition)
+      (respond-not-acceptable (jsown:new-js
+                                  ("errors" (jsown:new-js ("title" "Request invalid"))))))
+    (no-such-property (condition)
+      (let ((message
+             (format nil "Could not find property (~A) on resource (~A)."
+                     (path condition) (json-type (resource condition)))))
+        (respond-not-acceptable (jsown:new-js
+                                  ("errors" (jsown:new-js
+                                              ("title" message)))))))
+    (cl-fuseki:sesame-exception (exception)
+      (declare (ignore exception))
+      (respond-server-error
+       (jsown:new-js
+         ("errors" (jsown:new-js
+                     ("title" (s+ "Could not execute SPARQL query.")))))))
+    (configuration-error (condition)
+      (respond-server-error
+       (jsown:new-js
+         ("errors" (jsown:new-js
+                     ("title" (s+ "Server configuration issue: " (description condition))))))))
+    (incorrect-accept-header (condition)
+      (respond-not-acceptable (jsown:new-js
+                                ("errors" (jsown:new-js
+                                           ("title" (description condition)))))))
+    (error (condition)
+      (respond-general-server-error))))
+

--- a/config/resources/health-check.lisp
+++ b/config/resources/health-check.lisp
@@ -1,0 +1,4 @@
+(define-resource health-check ()
+  :class (s-prefix "ext:HealthCheck")
+  :resource-base (s-url "http://themis.vlaanderen.be/id/health-check/")
+  :on-path "health-checks")


### PR DESCRIPTION
Adds a dummy resource called `health-check` (with no data) that directly exposes mu-cl-resources via the dispatcher. This can then be used as an endpoint to check the status of mu-cl-resources.

:warning: Make sure to update the Prometheus config to enable monitoring on this new endpoint

Related PRs:
- [x] https://github.com/kanselarij-vlaanderen/app-valvas/pull/4