### PR TITLE
fix: follow the spec for end dates of mandates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 
 docker-compose.override.yml
 .log/
+
+.env

--- a/config/migrations/20230310115619-correctie-tijdzones-verwijder-incorrect.sparql
+++ b/config/migrations/20230310115619-correctie-tijdzones-verwijder-incorrect.sparql
@@ -1,0 +1,19 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+WITH <http://mu.semte.ch/graphs/public>
+DELETE {
+    ?mandataris mandaat:start ?start .
+}
+WHERE {
+    ?mandataris a mandaat:Mandataris ;
+                mandaat:start ?start .
+};
+WITH <http://mu.semte.ch/graphs/public>
+DELETE {
+    ?mandataris mandaat:einde ?einde .
+}
+WHERE {
+    ?mandataris a mandaat:Mandataris ;
+                mandaat:einde ?einde .
+}

--- a/config/migrations/20230310115620-correctie-tijdzones-insert-correct.graph
+++ b/config/migrations/20230310115620-correctie-tijdzones-insert-correct.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20230310115620-correctie-tijdzones-insert-correct.ttl
+++ b/config/migrations/20230310115620-correctie-tijdzones-insert-correct.ttl
@@ -1,0 +1,1793 @@
+@prefix ns1: <http://data.vlaanderen.be/ns/mandaat#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://themis.vlaanderen.be/id/mandataris/09684a8d-ac57-4c8b-9727-42ed9a477e55> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/10a45f51-a511-4caa-8273-d1eb2c1ee27c> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/1c829511-04b6-4ac4-99ad-06c6f1496535> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/1e207740-3834-4e98-8431-5a2c08704516> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/32ca24e2-e216-43e0-b0af-e377137c0775> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/345dfd2a-3c09-42bc-a3d1-99ac8c72f515> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/3dc729d9-94b7-41f7-8c91-cc30951d6a56> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/3f4bfdbf-a8c4-4687-937d-7608b1e4270c> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/43b0ffea-8395-42c2-aad5-c7796c0cd33a> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/4ca19c47-a57e-4fbf-95dd-8d4e09d71ed8> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/532a4a5b-eabe-4f93-bc3a-7ef5f8f3c26e> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5678ff3c-ef96-4d19-b5a9-b383adcc69aa> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/57d1cd49-58bf-438b-9ca4-dd521fb02066> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5deb9bb2-204a-4fbe-93ba-edeb5fa7a57b> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a03eb> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a03ee> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a03f0> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a03f2> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a03f4> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a03f8> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a03fc> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a03ff> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0404> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0407> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a040a> ns1:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a040e> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a040f> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0410> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0411> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0412> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0414> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0415> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0416> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0417> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0418> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0419> ns1:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0424> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0425> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0427> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0429> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a042a> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a042b> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a042c> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a042f> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0431> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0434> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0437> ns1:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0438> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0439> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a043a> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a043b> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a043c> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a043d> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a043e> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a043f> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0440> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0441> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0443> ns1:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a044e> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a044f> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0450> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0451> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0452> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0454> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0458> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a045a> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a045d> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0460> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0462> ns1:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0465> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0466> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0468> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a046b> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a046c> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a046d> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a046e> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a046f> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0470> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0471> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0473> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0475> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0477> ns1:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a047a> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a047b> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a047c> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a047d> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a047e> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a047f> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0480> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0481> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0482> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0483> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0484> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0485> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0486> ns1:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0487> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0488> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0489> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a048a> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a048b> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a048c> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a048d> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a048f> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0490> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0491> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0492> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a0493> ns1:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04a1> ns1:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04a2> ns1:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04a3> ns1:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04a5> ns1:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04a6> ns1:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04a8> ns1:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04a9> ns1:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04ac> ns1:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04ae> ns1:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04af> ns1:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04b1> ns1:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04b2> ns1:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04b3> ns1:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04b4> ns1:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04b5> ns1:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04b6> ns1:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04b7> ns1:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04ba> ns1:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04bc> ns1:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04be> ns1:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04bf> ns1:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04c0> ns1:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04c1> ns1:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04c2> ns1:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04c3> ns1:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04c4> ns1:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04c5> ns1:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04c6> ns1:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04c8> ns1:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04c9> ns1:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04ca> ns1:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04cb> ns1:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04cc> ns1:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04cd> ns1:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04ce> ns1:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04cf> ns1:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04d0> ns1:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04d1> ns1:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ce6670526694a04d2> ns1:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04d3> ns1:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04d4> ns1:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04d5> ns1:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04d6> ns1:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04d7> ns1:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04d8> ns1:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04d9> ns1:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04da> ns1:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04dc> ns1:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04dd> ns1:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04de> ns1:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04df> ns1:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04e0> ns1:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04e1> ns1:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04e2> ns1:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04e3> ns1:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04e4> ns1:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04f0> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04f5> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04f6> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04f7> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04f8> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04f9> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04fa> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04fd> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a04ff> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0501> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0505> ns1:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0507> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0508> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0509> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a050a> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a050b> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a050c> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a050d> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a050e> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a050f> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0510> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0512> ns1:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0513> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0514> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0515> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0516> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0517> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0518> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0519> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a051a> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a051b> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a051c> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a051d> ns1:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a051e> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a051f> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0521> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0522> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0523> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0524> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0525> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0526> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0527> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0528> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0529> ns1:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0534> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0535> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0536> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0538> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a053a> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a053e> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0541> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0543> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0546> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0547> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a054a> ns1:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a054b> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a054c> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a054d> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a054e> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a054f> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0550> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0552> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0553> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0554> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0555> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0556> ns1:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0557> ns1:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0558> ns1:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0559> ns1:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a055a> ns1:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a055b> ns1:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a055c> ns1:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a055d> ns1:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a055e> ns1:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a055f> ns1:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0560> ns1:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0561> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0562> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0563> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0564> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0565> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0566> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0567> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0568> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0569> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a056a> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a056c> ns1:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a056f> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0570> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0571> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0572> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0573> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0574> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0575> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0576> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0577> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0578> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a057a> ns1:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a057c> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a057d> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a057e> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a057f> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0580> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0581> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0582> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0583> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0585> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0586> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0588> ns1:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a058a> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a058b> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a058c> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a058d> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a058e> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a058f> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0590> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0591> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0592> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0595> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0598> ns1:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a059a> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a059b> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a059c> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a059d> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a059e> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05a1> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05a2> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05a3> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05a5> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05a7> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05a9> ns1:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05ac> ns1:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05ad> ns1:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05ae> ns1:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05af> ns1:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05b0> ns1:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05b1> ns1:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05b2> ns1:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05b3> ns1:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05b4> ns1:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05b5> ns1:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05ba> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05bb> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05bc> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05bd> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05be> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05bf> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05c0> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05c1> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05c2> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05c4> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05c7> ns1:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05ca> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05cb> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05cc> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05cd> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05ce> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05cf> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05d0> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05d1> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05d2> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05d3> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05d5> ns1:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05d9> ns1:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05da> ns1:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05db> ns1:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05dc> ns1:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05dd> ns1:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05de> ns1:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05df> ns1:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05e0> ns1:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05e1> ns1:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05ed> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05f1> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05f3> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05f4> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05f6> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05f8> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05fa> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05fb> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05fc> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a05ff> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0602> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0604> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0609> ns1:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a060d> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a060e> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a060f> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0611> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0612> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0613> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0614> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0615> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0616> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0617> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0618> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a061a> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a061c> ns1:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a061d> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a061f> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0620> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0621> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0622> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0623> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0624> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0625> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0626> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0627> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0628> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0629> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a062a> ns1:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a062b> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a062c> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a062d> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a062e> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a062f> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0630> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0631> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0632> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0633> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0634> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0635> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0636> ns1:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0637> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0638> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0639> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a063a> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a063b> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a063c> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a063d> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a063e> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a063f> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0640> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0641> ns1:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0642> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0643> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0644> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907de6670526694a0645> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0646> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0647> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0648> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0649> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a064a> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a064b> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a064c> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a064e> ns1:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0659> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a065a> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a065c> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a065f> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0661> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0662> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0664> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0667> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0669> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a066a> ns1:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a066b> ns1:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a066c> ns1:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a066d> ns1:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a066e> ns1:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a066f> ns1:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0670> ns1:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0671> ns1:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0672> ns1:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0673> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0674> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0675> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0676> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0677> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0679> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a067a> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a067b> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a067c> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a067d> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a067e> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0680> ns1:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a068b> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a068d> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a068e> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a068f> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0691> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0692> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0694> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0696> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0698> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a069a> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a069b> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a069c> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a069f> ns1:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06a1> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06a2> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06a3> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06a4> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06a5> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06a6> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06a7> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06a8> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06a9> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06aa> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ab> ns1:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ac> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ad> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ae> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06af> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06b1> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06b2> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06b3> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06b4> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06b5> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06b6> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06b7> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06b8> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06b9> ns1:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ba> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06bb> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06bc> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06bd> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06be> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06bf> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06c0> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06c1> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06c2> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06c3> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06c4> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06c5> ns1:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06c6> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06c7> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06c8> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06c9> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ca> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06cb> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06cc> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06cd> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ce> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06cf> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06d0> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06d1> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06d3> ns1:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06d4> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06d5> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06d6> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06d7> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06d8> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06d9> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06da> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06db> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06dc> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06dd> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06de> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06df> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06e1> ns1:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06e4> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06e5> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06e6> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06e7> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06e8> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06e9> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ea> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06eb> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ec> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ed> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06ee> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06f0> ns1:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06f1> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06f2> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06f3> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06f4> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06f5> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06f6> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06f7> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06f8> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06f9> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06fa> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06fb> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a06fc> ns1:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0708> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a070c> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a070d> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a070f> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0710> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0711> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0712> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0713> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0715> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a0719> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a071b> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a071c> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/5fed907ee6670526694a071e> ns1:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/60f3b4dc-ad5c-4722-9a69-baf991384412> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/74cf5db5-8b6c-442e-baf4-97fbc896f986> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/763a0c72-6bd3-4670-9ff3-6246b58ba5f1> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/7cad1801-dfd1-44a6-bdfa-5d4e8259d023> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/81e6ca1b-97c1-4572-ae79-fba4ccb91e91> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/94e1a665-19ba-4ed8-97ae-a6061e60349d> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/95cfe981-9d27-4f00-8e50-28519f068e23> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/9ce68339-a517-4501-8302-60472167a8d4> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/9daab663-7277-4080-85cb-d768feb5242b> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/9f1a1fd0-d4ef-4456-8d73-508847351f20> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/a390a4fb-1be7-4128-afd0-e38da7883e5d> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/b7834d9e-8373-4ec2-a124-2623594c772a> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/bd63fe69-25df-4b36-a4f0-c7b87157a89b> ns1:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/c66e1c4b-e01f-43c5-88e4-36112ba21db5> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/c88ce55a-a1f8-4d99-b2a8-fff46f62e4e4> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/cabd47da-7956-4c21-83b3-539fd0f4a4de> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/cfa50017-b0c5-4638-bb0c-bf486d0dd63b> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/d437d986-09de-4b46-8fce-f6ca4389f492> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/d52fcc41-d25f-451b-be35-102f650517ab> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/d89222e1-eb8a-411f-8889-b1c1b688ab90> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/dc380cfb-3987-42bb-afc6-8e079e64ff63> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/dc66d32b-be05-43b8-ac18-0d91fdf8c6ec> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/e2242233-4b72-4079-bb20-d196da78edbb> ns1:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/e86d0c8a-6182-4f73-b921-4a67771a18e0> ns1:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns1:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandataris/ed9edaf1-18b5-41ee-ab65-21c70fac2a8b> ns1:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/145bafde-10ea-4a73-8fe9-042cdea3ccbe> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/14d57d14-5922-4a7b-8574-1b682df71145> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/1c62a2f3-cc0c-4760-ada9-90c7f879369e> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/34405d19-996f-4f9e-8616-a30e6f3a1175> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/38e5e0e9-52c7-4f7d-b92b-16eee0edd193> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/43c129cc-ba12-4457-b93e-737b7370c46e> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/488d5ce1-bed5-400c-985a-734ff6e296f5> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/4eae2f7e-ca9f-42d6-abed-dcd4ab56fd65> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/6ace9621-2236-4023-b77d-f4cb8dec1565> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/758e0782-fa7e-4740-a5fa-032e4c0d04ca> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/7c4c08aa-b058-4656-8aac-cd9946cbeac3> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/8d2639a1-afca-467c-b7a8-9ba01fa54852> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/8dcdc330-348d-4f69-b10c-02f584adb9af> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/a55415f4-a212-4ff0-b8e6-3bc1799361af> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/aa642a1e-7cc4-44da-9a6b-bce625761c5f> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/b374d85b-428d-4177-910d-0f7077cb3311> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/bb2e174a-374e-447d-ad0c-002204b4561f> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/c665812d-820d-4f77-a559-e8c757a82302> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/d283fd40-f781-4300-a913-60658e2aec85> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/d7593ea4-a74d-403d-beeb-8f9ed0fbb082> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/ddcf86cf-387e-4afc-a38f-2e183ce46909> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/e6652d4d-418b-4060-b309-084d6f0a60fe> ns1:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns1:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/e8706d05-70b7-4b5c-ba75-f07c56cb259f> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/e92489ff-126c-4569-a15e-ae8e193be345> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/mandatee/f7fe3320-7c15-4322-b907-02571d3dfe6e> ns1:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime .
+

--- a/config/migrations/20230310115621-correctie-tijdzones-dcat-dataset.graph
+++ b/config/migrations/20230310115621-correctie-tijdzones-dcat-dataset.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20230310115621-correctie-tijdzones-dcat-dataset.ttl
+++ b/config/migrations/20230310115621-correctie-tijdzones-dcat-dataset.ttl
@@ -1,0 +1,46 @@
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#> .
+@prefix dbpedia: <http://dbpedia.org/resource/> .
+
+# dataset is part of catalog
+<http://themis.vlaanderen.be/id/catalog/1e4733c1-7701-4f99-b3db-f5d348a7bc4b> dcat:dataset <http://themis.vlaanderen.be/id/dataset/87b6f1d9-9951-496c-a36e-47d4d85b0f7f> .
+
+# This VR ministers dataset is a revision of the previous VR ministers dataset
+<http://themis.vlaanderen.be/id/dataset/87b6f1d9-9951-496c-a36e-47d4d85b0f7f> <http://www.w3.org/ns/prov#wasRevisionOf> <http://themis.vlaanderen.be/id/dataset/eee011e6-7752-4031-9a27-16c9c72e25be> .
+
+<http://themis.vlaanderen.be/id/dataset/87b6f1d9-9951-496c-a36e-47d4d85b0f7f> a dcat:Dataset ;
+    mu:uuid "87b6f1d9-9951-496c-a36e-47d4d85b0f7f" ;
+    dct:title "Minister dataset" ;
+    dct:type <http://themis.vlaanderen.be/id/concept/dataset-type/43c644d3-2171-4892-8dd7-3fd5eec15d09> ;
+    dct:issued "2023-03-07T16:00:00+02:00"^^xsd:dateTime ;
+    dct:modified "2023-03-07T16:00:00+02:00"^^xsd:dateTime ;
+    dcat:distribution <http://themis.vlaanderen.be/id/distribution/f38f9b99-31b6-4d36-856a-08970c465eed> .
+
+<http://themis.vlaanderen.be/id/distribution/f38f9b99-31b6-4d36-856a-08970c465eed> a dcat:Distribution ;
+    mu:uuid "f38f9b99-31b6-4d36-856a-08970c465eed" ;
+    dct:issued "2023-03-07T16:00:00+02:00"^^xsd:dateTime ;
+    dct:modified "2023-03-07T16:00:00+02:00"^^xsd:dateTime ;
+    dcat:downloadURL <https://themis.vlaanderen.be/files/79ffa070-c47b-4e5f-88e2-eb3e23a33c7e/download> ;
+    dct:format "text/turtle" ;
+    dcat:byteSize "441002"^^xsd:integer .
+
+<http://themis.vlaanderen.be/id/file/79ffa070-c47b-4e5f-88e2-eb3e23a33c7e> a nfo:FileDataObject ;
+    mu:uuid "79ffa070-c47b-4e5f-88e2-eb3e23a33c7e" ;
+    nfo:fileName "ministers-vlaamse-regering.ttl" ;
+    dct:format "text/turtle" ;
+    nfo:fileSize "441002"^^xsd:integer ;
+    dct:created "2023-03-07T16:00:00+02:00"^^xsd:dateTime ;
+    dbpedia:fileExtension "ttl" .
+
+<share://b5b07a0a-ee17-4cd2-95c0-eb6f2e05c230.ttl> a nfo:FileDataObject ;
+    mu:uuid "b5b07a0a-ee17-4cd2-95c0-eb6f2e05c230" ;
+    nfo:fileName "b5b07a0a-ee17-4cd2-95c0-eb6f2e05c230.ttl" ;
+    dct:format "text/turtle" ;
+    nfo:fileSize "441002"^^xsd:integer ;
+    dct:created "2023-03-07T16:00:00+02:00"^^xsd:dateTime ;
+    dbpedia:fileExtension "ttl" ;
+    nie:dataSource <http://themis.vlaanderen.be/id/file/79ffa070-c47b-4e5f-88e2-eb3e23a33c7e> .

--- a/data/files/b5b07a0a-ee17-4cd2-95c0-eb6f2e05c230.ttl
+++ b/data/files/b5b07a0a-ee17-4cd2-95c0-eb6f2e05c230.ttl
@@ -1,0 +1,7765 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ns1: <http://themis.vlaanderen.be/id/concept-scheme/> .
+@prefix ns10: <http://themis.vlaanderen.be/id/bestuurseenheid/> .
+@prefix ns11: <http://data.vlaanderen.be/ns/besluit#> .
+@prefix ns12: <http://www.w3.org/ns/org#> .
+@prefix ns13: <http://themis.vlaanderen.be/id/concept/activity-type/> .
+@prefix ns16: <http://themis.vlaanderen.be/id/concept/thema/> .
+@prefix ns17: <http://data.vlaanderen.be/ns/mandaat#> .
+@prefix ns18: <http://www.w3.org/ns/person#> .
+@prefix ns19: <https://data.vlaanderen.be/ns/persoon#> .
+@prefix ns21: <http://purl.org/dc/terms/> .
+@prefix ns22: <http://www.w3.org/ns/prov#> .
+@prefix ns23: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix ns24: <http://data.vlaanderen.be/id/conceptscheme/> .
+@prefix ns25: <http://themis.vlaanderen.be/id/opheffing/> .
+@prefix ns26: <http://themis.vlaanderen.be/id/mandataris/> .
+@prefix ns27: <http://themis.vlaanderen.be/id/mandatee/> .
+@prefix ns3: <http://mu.semte.ch/vocabularies/core/> .
+@prefix ns4: <http://themis.vlaanderen.be/id/concept/distribution-type/> .
+@prefix ns5: <http://themis.vlaanderen.be/id/concept/agenda-status/> .
+@prefix ns6: <http://themis.vlaanderen.be/id/concept/document-type/> .
+@prefix ns7: <http://themis.vlaanderen.be/id/concept/agendapunt-type/> .
+@prefix ns8: <http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/> .
+@prefix ns9: <http://themis.vlaanderen.be/id/concept/bestuurseenheid-classificatie/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e1> a ns12:Role ;
+    ns3:uuid "5fed907ce6670526694a03e1" ;
+    skos:inScheme ns24:BestuursfunctieCode ;
+    skos:prefLabel "Volksvertegenwoordiger" .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/17caac00-34a2-4b84-b400-30823555c15e> a ns11:Bestuursorgaan ;
+    ns11:bestuurt ns10:60d0dc2ab1838d01fca7db64,
+        ns10:e7a239de-c48c-441c-8293-ec365eedce93 ;
+    ns3:uuid "17caac00-34a2-4b84-b400-30823555c15e" ;
+    skos:prefLabel "Vlaams Parlement" ;
+    ns12:classification <http://themis.vlaanderen.be/id/concept/bestuursorgaan-classificatie/14b3f492-7106-46c7-9704-f547beff18ca> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a03e9> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ce6670526694a03e9" ;
+    skos:prefLabel "Geens I" ;
+    ns22:hadMember ns26:5fed907ce6670526694a03eb,
+        ns26:5fed907ce6670526694a03ee,
+        ns26:5fed907ce6670526694a03f0,
+        ns26:5fed907ce6670526694a03f2,
+        ns26:5fed907ce6670526694a03f4,
+        ns26:5fed907ce6670526694a03f8,
+        ns26:5fed907ce6670526694a03fc,
+        ns26:5fed907ce6670526694a03ff,
+        ns26:5fed907ce6670526694a0404,
+        ns26:5fed907ce6670526694a0407,
+        ns26:5fed907ce6670526694a040a,
+        ns26:5fed907ce6670526694a040e,
+        ns26:5fed907ce6670526694a040f,
+        ns26:5fed907ce6670526694a0410,
+        ns26:5fed907ce6670526694a0411,
+        ns26:5fed907ce6670526694a0412,
+        ns26:5fed907ce6670526694a0414,
+        ns26:5fed907ce6670526694a0415,
+        ns26:5fed907ce6670526694a0416,
+        ns26:5fed907ce6670526694a0417,
+        ns26:5fed907ce6670526694a0418,
+        ns26:5fed907ce6670526694a0419 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a03e8> ;
+    ns22:qualifiedInvalidation ns25:5fed907ce6670526694a041c ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a03e3> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a0423> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ce6670526694a0423" ;
+    skos:prefLabel "Geens II" ;
+    ns22:hadMember ns26:5fed907ce6670526694a0424,
+        ns26:5fed907ce6670526694a0425,
+        ns26:5fed907ce6670526694a0427,
+        ns26:5fed907ce6670526694a0429,
+        ns26:5fed907ce6670526694a042a,
+        ns26:5fed907ce6670526694a042b,
+        ns26:5fed907ce6670526694a042c,
+        ns26:5fed907ce6670526694a042f,
+        ns26:5fed907ce6670526694a0431,
+        ns26:5fed907ce6670526694a0434,
+        ns26:5fed907ce6670526694a0437,
+        ns26:5fed907ce6670526694a0438,
+        ns26:5fed907ce6670526694a0439,
+        ns26:5fed907ce6670526694a043a,
+        ns26:5fed907ce6670526694a043b,
+        ns26:5fed907ce6670526694a043c,
+        ns26:5fed907ce6670526694a043d,
+        ns26:5fed907ce6670526694a043e,
+        ns26:5fed907ce6670526694a043f,
+        ns26:5fed907ce6670526694a0440,
+        ns26:5fed907ce6670526694a0441,
+        ns26:5fed907ce6670526694a0443 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a0422> ;
+    ns22:qualifiedInvalidation ns25:5fed907ce6670526694a0446 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a041d> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a044d> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ce6670526694a044d" ;
+    skos:prefLabel "Geens III" ;
+    ns22:hadMember ns26:5fed907ce6670526694a044e,
+        ns26:5fed907ce6670526694a044f,
+        ns26:5fed907ce6670526694a0450,
+        ns26:5fed907ce6670526694a0451,
+        ns26:5fed907ce6670526694a0452,
+        ns26:5fed907ce6670526694a0454,
+        ns26:5fed907ce6670526694a0458,
+        ns26:5fed907ce6670526694a045a,
+        ns26:5fed907ce6670526694a045d,
+        ns26:5fed907ce6670526694a0460,
+        ns26:5fed907ce6670526694a0462 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a044c> ;
+    ns22:qualifiedInvalidation ns25:213ac49c-d7af-4444-ad18-a75f9196d3c5 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a0447> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a0464> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ce6670526694a0464" ;
+    skos:prefLabel "Geens IV" ;
+    ns22:hadMember ns26:5fed907ce6670526694a0465,
+        ns26:5fed907ce6670526694a0466,
+        ns26:5fed907ce6670526694a0468,
+        ns26:5fed907ce6670526694a046b,
+        ns26:5fed907ce6670526694a046c,
+        ns26:5fed907ce6670526694a046d,
+        ns26:5fed907ce6670526694a046e,
+        ns26:5fed907ce6670526694a046f,
+        ns26:5fed907ce6670526694a0470,
+        ns26:5fed907ce6670526694a0471,
+        ns26:5fed907ce6670526694a0473,
+        ns26:5fed907ce6670526694a0475,
+        ns26:5fed907ce6670526694a0477,
+        ns26:5fed907ce6670526694a047a,
+        ns26:5fed907ce6670526694a047b,
+        ns26:5fed907ce6670526694a047c,
+        ns26:5fed907ce6670526694a047d,
+        ns26:5fed907ce6670526694a047e,
+        ns26:5fed907ce6670526694a047f,
+        ns26:5fed907ce6670526694a0480,
+        ns26:5fed907ce6670526694a0481,
+        ns26:5fed907ce6670526694a0482,
+        ns26:5fed907ce6670526694a0483,
+        ns26:5fed907ce6670526694a0484,
+        ns26:5fed907ce6670526694a0485,
+        ns26:5fed907ce6670526694a0486,
+        ns26:5fed907ce6670526694a0487,
+        ns26:5fed907ce6670526694a0488,
+        ns26:5fed907ce6670526694a0489,
+        ns26:5fed907ce6670526694a048a,
+        ns26:5fed907ce6670526694a048b,
+        ns26:5fed907ce6670526694a048c,
+        ns26:5fed907ce6670526694a048d,
+        ns26:5fed907ce6670526694a048f,
+        ns26:5fed907ce6670526694a0490,
+        ns26:5fed907ce6670526694a0491,
+        ns26:5fed907ce6670526694a0492,
+        ns26:5fed907ce6670526694a0493 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a0463> ;
+    ns22:qualifiedInvalidation ns25:5fed907ce6670526694a0498 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a0447> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a049f> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ce6670526694a049f" ;
+    skos:prefLabel "Van den Brande I (VE)" ;
+    ns22:hadMember ns26:5fed907ce6670526694a04a1,
+        ns26:5fed907ce6670526694a04a2,
+        ns26:5fed907ce6670526694a04a3,
+        ns26:5fed907ce6670526694a04a5,
+        ns26:5fed907ce6670526694a04a6,
+        ns26:5fed907ce6670526694a04a8,
+        ns26:5fed907ce6670526694a04a9,
+        ns26:5fed907ce6670526694a04ac,
+        ns26:5fed907ce6670526694a04ae,
+        ns26:5fed907ce6670526694a04af,
+        ns26:5fed907ce6670526694a04b1,
+        ns26:5fed907ce6670526694a04b2,
+        ns26:5fed907ce6670526694a04b3,
+        ns26:5fed907ce6670526694a04b4,
+        ns26:5fed907ce6670526694a04b5,
+        ns26:5fed907ce6670526694a04b6,
+        ns26:5fed907ce6670526694a04b7,
+        ns26:5fed907ce6670526694a04ba,
+        ns26:5fed907ce6670526694a04bc ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a049e> ;
+    ns22:qualifiedInvalidation ns25:5fed907de6670526694a04e8 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a0499> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a04ef> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907de6670526694a04ef" ;
+    skos:prefLabel "Van den Brande II" ;
+    ns22:hadMember ns26:5fed907de6670526694a04f0,
+        ns26:5fed907de6670526694a04f5,
+        ns26:5fed907de6670526694a04f6,
+        ns26:5fed907de6670526694a04f7,
+        ns26:5fed907de6670526694a04f8,
+        ns26:5fed907de6670526694a04f9,
+        ns26:5fed907de6670526694a04fa,
+        ns26:5fed907de6670526694a04fd,
+        ns26:5fed907de6670526694a04ff,
+        ns26:5fed907de6670526694a0501,
+        ns26:5fed907de6670526694a0505,
+        ns26:5fed907de6670526694a0507,
+        ns26:5fed907de6670526694a0508,
+        ns26:5fed907de6670526694a0509,
+        ns26:5fed907de6670526694a050a,
+        ns26:5fed907de6670526694a050b,
+        ns26:5fed907de6670526694a050c,
+        ns26:5fed907de6670526694a050d,
+        ns26:5fed907de6670526694a050e,
+        ns26:5fed907de6670526694a050f,
+        ns26:5fed907de6670526694a0510,
+        ns26:5fed907de6670526694a0512,
+        ns26:5fed907de6670526694a0513,
+        ns26:5fed907de6670526694a0514,
+        ns26:5fed907de6670526694a0515,
+        ns26:5fed907de6670526694a0516,
+        ns26:5fed907de6670526694a0517,
+        ns26:5fed907de6670526694a0518,
+        ns26:5fed907de6670526694a0519,
+        ns26:5fed907de6670526694a051a,
+        ns26:5fed907de6670526694a051b,
+        ns26:5fed907de6670526694a051c,
+        ns26:5fed907de6670526694a051d,
+        ns26:5fed907de6670526694a051e,
+        ns26:5fed907de6670526694a051f,
+        ns26:5fed907de6670526694a0521,
+        ns26:5fed907de6670526694a0522,
+        ns26:5fed907de6670526694a0523,
+        ns26:5fed907de6670526694a0524,
+        ns26:5fed907de6670526694a0525,
+        ns26:5fed907de6670526694a0526,
+        ns26:5fed907de6670526694a0527,
+        ns26:5fed907de6670526694a0528,
+        ns26:5fed907de6670526694a0529 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a04ee> ;
+    ns22:qualifiedInvalidation ns25:5fed907de6670526694a052c ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a04e9> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a0533> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907de6670526694a0533" ;
+    skos:prefLabel "Dewael I" ;
+    ns22:hadMember ns26:09684a8d-ac57-4c8b-9727-42ed9a477e55,
+        ns26:1c829511-04b6-4ac4-99ad-06c6f1496535,
+        ns26:345dfd2a-3c09-42bc-a3d1-99ac8c72f515,
+        ns26:3f4bfdbf-a8c4-4687-937d-7608b1e4270c,
+        ns26:43b0ffea-8395-42c2-aad5-c7796c0cd33a,
+        ns26:4ca19c47-a57e-4fbf-95dd-8d4e09d71ed8,
+        ns26:532a4a5b-eabe-4f93-bc3a-7ef5f8f3c26e,
+        ns26:57d1cd49-58bf-438b-9ca4-dd521fb02066,
+        ns26:5fed907de6670526694a0534,
+        ns26:5fed907de6670526694a0535,
+        ns26:5fed907de6670526694a0536,
+        ns26:5fed907de6670526694a0538,
+        ns26:5fed907de6670526694a053a,
+        ns26:5fed907de6670526694a053e,
+        ns26:5fed907de6670526694a0541,
+        ns26:5fed907de6670526694a0543,
+        ns26:5fed907de6670526694a0546,
+        ns26:5fed907de6670526694a0547,
+        ns26:5fed907de6670526694a054a,
+        ns26:5fed907de6670526694a054b,
+        ns26:5fed907de6670526694a054c,
+        ns26:5fed907de6670526694a054d,
+        ns26:5fed907de6670526694a054e,
+        ns26:5fed907de6670526694a054f,
+        ns26:5fed907de6670526694a0550,
+        ns26:5fed907de6670526694a0552,
+        ns26:5fed907de6670526694a0553,
+        ns26:5fed907de6670526694a0554,
+        ns26:5fed907de6670526694a0555,
+        ns26:5fed907de6670526694a0556,
+        ns26:5fed907de6670526694a0557,
+        ns26:5fed907de6670526694a0558,
+        ns26:5fed907de6670526694a0559,
+        ns26:5fed907de6670526694a055a,
+        ns26:5fed907de6670526694a055b,
+        ns26:5fed907de6670526694a055c,
+        ns26:5fed907de6670526694a055d,
+        ns26:5fed907de6670526694a055e,
+        ns26:5fed907de6670526694a055f,
+        ns26:5fed907de6670526694a0560,
+        ns26:5fed907de6670526694a0561,
+        ns26:5fed907de6670526694a0562,
+        ns26:5fed907de6670526694a0563,
+        ns26:5fed907de6670526694a0564,
+        ns26:5fed907de6670526694a0565,
+        ns26:5fed907de6670526694a0566,
+        ns26:5fed907de6670526694a0567,
+        ns26:5fed907de6670526694a0568,
+        ns26:5fed907de6670526694a0569,
+        ns26:5fed907de6670526694a056a,
+        ns26:5fed907de6670526694a056c,
+        ns26:5fed907de6670526694a056f,
+        ns26:5fed907de6670526694a0570,
+        ns26:5fed907de6670526694a0571,
+        ns26:5fed907de6670526694a0572,
+        ns26:5fed907de6670526694a0573,
+        ns26:5fed907de6670526694a0574,
+        ns26:5fed907de6670526694a0575,
+        ns26:5fed907de6670526694a0576,
+        ns26:5fed907de6670526694a0577,
+        ns26:5fed907de6670526694a0578,
+        ns26:5fed907de6670526694a057a,
+        ns26:5fed907de6670526694a057c,
+        ns26:5fed907de6670526694a057d,
+        ns26:5fed907de6670526694a057e,
+        ns26:5fed907de6670526694a057f,
+        ns26:5fed907de6670526694a0580,
+        ns26:5fed907de6670526694a0581,
+        ns26:5fed907de6670526694a0582,
+        ns26:5fed907de6670526694a0583,
+        ns26:5fed907de6670526694a0585,
+        ns26:5fed907de6670526694a0586,
+        ns26:5fed907de6670526694a0588,
+        ns26:5fed907de6670526694a058a,
+        ns26:5fed907de6670526694a058b,
+        ns26:5fed907de6670526694a058c,
+        ns26:5fed907de6670526694a058d,
+        ns26:5fed907de6670526694a058e,
+        ns26:5fed907de6670526694a058f,
+        ns26:5fed907de6670526694a0590,
+        ns26:5fed907de6670526694a0591,
+        ns26:5fed907de6670526694a0592,
+        ns26:5fed907de6670526694a0595,
+        ns26:5fed907de6670526694a0598,
+        ns26:5fed907de6670526694a059a,
+        ns26:5fed907de6670526694a059b,
+        ns26:5fed907de6670526694a059c,
+        ns26:5fed907de6670526694a059d,
+        ns26:5fed907de6670526694a059e,
+        ns26:5fed907de6670526694a05a1,
+        ns26:5fed907de6670526694a05a2,
+        ns26:5fed907de6670526694a05a3,
+        ns26:5fed907de6670526694a05a5,
+        ns26:5fed907de6670526694a05a7,
+        ns26:5fed907de6670526694a05a9,
+        ns26:60f3b4dc-ad5c-4722-9a69-baf991384412,
+        ns26:763a0c72-6bd3-4670-9ff3-6246b58ba5f1,
+        ns26:7cad1801-dfd1-44a6-bdfa-5d4e8259d023,
+        ns26:94e1a665-19ba-4ed8-97ae-a6061e60349d,
+        ns26:95cfe981-9d27-4f00-8e50-28519f068e23,
+        ns26:9ce68339-a517-4501-8302-60472167a8d4,
+        ns26:9daab663-7277-4080-85cb-d768feb5242b,
+        ns26:9f1a1fd0-d4ef-4456-8d73-508847351f20,
+        ns26:b7834d9e-8373-4ec2-a124-2623594c772a,
+        ns26:c66e1c4b-e01f-43c5-88e4-36112ba21db5,
+        ns26:c88ce55a-a1f8-4d99-b2a8-fff46f62e4e4,
+        ns26:cfa50017-b0c5-4638-bb0c-bf486d0dd63b,
+        ns26:d52fcc41-d25f-451b-be35-102f650517ab,
+        ns26:e86d0c8a-6182-4f73-b921-4a67771a18e0,
+        ns26:ed9edaf1-18b5-41ee-ab65-21c70fac2a8b ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a0532> ;
+    ns22:qualifiedInvalidation ns25:0a630d03-e849-4ea6-98e1-e041f9098174 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a052d> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a05ab> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907de6670526694a05ab" ;
+    skos:prefLabel "Interimregering 2003" ;
+    ns22:hadMember ns26:5fed907de6670526694a05ac,
+        ns26:5fed907de6670526694a05ad,
+        ns26:5fed907de6670526694a05ae,
+        ns26:5fed907de6670526694a05af,
+        ns26:5fed907de6670526694a05b0,
+        ns26:5fed907de6670526694a05b1,
+        ns26:5fed907de6670526694a05b2,
+        ns26:5fed907de6670526694a05b3,
+        ns26:5fed907de6670526694a05b4,
+        ns26:5fed907de6670526694a05b5 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a05aa> ;
+    ns22:qualifiedInvalidation ns25:65b20fa7-30ea-4d1d-ba3c-8caeca0f4394 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a052d> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a05b7> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907de6670526694a05b7" ;
+    skos:prefLabel "Somers I" ;
+    ns22:hadMember ns26:5fed907de6670526694a05ba,
+        ns26:5fed907de6670526694a05bb,
+        ns26:5fed907de6670526694a05bc,
+        ns26:5fed907de6670526694a05bd,
+        ns26:5fed907de6670526694a05be,
+        ns26:5fed907de6670526694a05bf,
+        ns26:5fed907de6670526694a05c0,
+        ns26:5fed907de6670526694a05c1,
+        ns26:5fed907de6670526694a05c2,
+        ns26:5fed907de6670526694a05c4,
+        ns26:5fed907de6670526694a05c7,
+        ns26:5fed907de6670526694a05ca,
+        ns26:5fed907de6670526694a05cb,
+        ns26:5fed907de6670526694a05cc,
+        ns26:5fed907de6670526694a05cd,
+        ns26:5fed907de6670526694a05ce,
+        ns26:5fed907de6670526694a05cf,
+        ns26:5fed907de6670526694a05d0,
+        ns26:5fed907de6670526694a05d1,
+        ns26:5fed907de6670526694a05d2,
+        ns26:5fed907de6670526694a05d3,
+        ns26:5fed907de6670526694a05d5 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a05b6> ;
+    ns22:qualifiedInvalidation ns25:a6e42d82-73af-4472-be9c-2295cc2c91d9 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a052d> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a05d7> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907de6670526694a05d7" ;
+    skos:prefLabel "interimregering 2004" ;
+    ns22:hadMember ns26:5fed907de6670526694a05d9,
+        ns26:5fed907de6670526694a05da,
+        ns26:5fed907de6670526694a05db,
+        ns26:5fed907de6670526694a05dc,
+        ns26:5fed907de6670526694a05dd,
+        ns26:5fed907de6670526694a05de,
+        ns26:5fed907de6670526694a05df,
+        ns26:5fed907de6670526694a05e0,
+        ns26:5fed907de6670526694a05e1 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a05d6> ;
+    ns22:qualifiedInvalidation ns25:5fed907de6670526694a05e4 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a052d> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a05eb> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907de6670526694a05eb" ;
+    skos:prefLabel "Leterme" ;
+    ns22:hadMember ns26:5fed907de6670526694a05ed,
+        ns26:5fed907de6670526694a05f1,
+        ns26:5fed907de6670526694a05f3,
+        ns26:5fed907de6670526694a05f4,
+        ns26:5fed907de6670526694a05f6,
+        ns26:5fed907de6670526694a05f8,
+        ns26:5fed907de6670526694a05fa,
+        ns26:5fed907de6670526694a05fb,
+        ns26:5fed907de6670526694a05fc,
+        ns26:5fed907de6670526694a05ff,
+        ns26:5fed907de6670526694a0602,
+        ns26:5fed907de6670526694a0604,
+        ns26:5fed907de6670526694a0609 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a05ea> ;
+    ns22:qualifiedInvalidation ns25:dc8685f9-ec92-41ed-9ac5-f4526df96d38 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a05e5> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a060c> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907de6670526694a060c" ;
+    skos:prefLabel "Peeters I" ;
+    ns22:hadMember ns26:5fed907de6670526694a060d,
+        ns26:5fed907de6670526694a060e,
+        ns26:5fed907de6670526694a060f,
+        ns26:5fed907de6670526694a0611,
+        ns26:5fed907de6670526694a0612,
+        ns26:5fed907de6670526694a0613,
+        ns26:5fed907de6670526694a0614,
+        ns26:5fed907de6670526694a0615,
+        ns26:5fed907de6670526694a0616,
+        ns26:5fed907de6670526694a0617,
+        ns26:5fed907de6670526694a0618,
+        ns26:5fed907de6670526694a061a,
+        ns26:5fed907de6670526694a061c,
+        ns26:5fed907de6670526694a061d,
+        ns26:5fed907de6670526694a061f,
+        ns26:5fed907de6670526694a0620,
+        ns26:5fed907de6670526694a0621,
+        ns26:5fed907de6670526694a0622,
+        ns26:5fed907de6670526694a0623,
+        ns26:5fed907de6670526694a0624,
+        ns26:5fed907de6670526694a0625,
+        ns26:5fed907de6670526694a0626,
+        ns26:5fed907de6670526694a0627,
+        ns26:5fed907de6670526694a0628,
+        ns26:5fed907de6670526694a0629,
+        ns26:5fed907de6670526694a062a,
+        ns26:5fed907de6670526694a062b,
+        ns26:5fed907de6670526694a062c,
+        ns26:5fed907de6670526694a062d,
+        ns26:5fed907de6670526694a062e,
+        ns26:5fed907de6670526694a062f,
+        ns26:5fed907de6670526694a0630,
+        ns26:5fed907de6670526694a0631,
+        ns26:5fed907de6670526694a0632,
+        ns26:5fed907de6670526694a0633,
+        ns26:5fed907de6670526694a0634,
+        ns26:5fed907de6670526694a0635,
+        ns26:5fed907de6670526694a0636,
+        ns26:5fed907de6670526694a0637,
+        ns26:5fed907de6670526694a0638,
+        ns26:5fed907de6670526694a0639,
+        ns26:5fed907de6670526694a063a,
+        ns26:5fed907de6670526694a063b,
+        ns26:5fed907de6670526694a063c,
+        ns26:5fed907de6670526694a063d,
+        ns26:5fed907de6670526694a063e,
+        ns26:5fed907de6670526694a063f,
+        ns26:5fed907de6670526694a0640,
+        ns26:5fed907de6670526694a0641,
+        ns26:5fed907de6670526694a0642,
+        ns26:5fed907de6670526694a0643,
+        ns26:5fed907de6670526694a0644,
+        ns26:5fed907de6670526694a0645,
+        ns26:5fed907ee6670526694a0646,
+        ns26:5fed907ee6670526694a0647,
+        ns26:5fed907ee6670526694a0648,
+        ns26:5fed907ee6670526694a0649,
+        ns26:5fed907ee6670526694a064a,
+        ns26:5fed907ee6670526694a064b,
+        ns26:5fed907ee6670526694a064c,
+        ns26:5fed907ee6670526694a064e ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a060b> ;
+    ns22:qualifiedInvalidation ns25:5fed907ee6670526694a0651 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a05e5> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0658> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ee6670526694a0658" ;
+    skos:prefLabel "Peeters II" ;
+    ns22:hadMember ns26:10a45f51-a511-4caa-8273-d1eb2c1ee27c,
+        ns26:32ca24e2-e216-43e0-b0af-e377137c0775,
+        ns26:5fed907ee6670526694a0659,
+        ns26:5fed907ee6670526694a065a,
+        ns26:5fed907ee6670526694a065c,
+        ns26:5fed907ee6670526694a065f,
+        ns26:5fed907ee6670526694a0661,
+        ns26:5fed907ee6670526694a0662,
+        ns26:5fed907ee6670526694a0664,
+        ns26:5fed907ee6670526694a0667,
+        ns26:5fed907ee6670526694a0669,
+        ns26:5fed907ee6670526694a066a,
+        ns26:5fed907ee6670526694a066b,
+        ns26:5fed907ee6670526694a066c,
+        ns26:5fed907ee6670526694a066d,
+        ns26:5fed907ee6670526694a066e,
+        ns26:5fed907ee6670526694a066f,
+        ns26:5fed907ee6670526694a0670,
+        ns26:5fed907ee6670526694a0671,
+        ns26:5fed907ee6670526694a0672,
+        ns26:5fed907ee6670526694a0673,
+        ns26:5fed907ee6670526694a0674,
+        ns26:5fed907ee6670526694a0675,
+        ns26:5fed907ee6670526694a0676,
+        ns26:5fed907ee6670526694a0677,
+        ns26:5fed907ee6670526694a0679,
+        ns26:5fed907ee6670526694a067a,
+        ns26:5fed907ee6670526694a067b,
+        ns26:5fed907ee6670526694a067c,
+        ns26:5fed907ee6670526694a067d,
+        ns26:5fed907ee6670526694a067e,
+        ns26:5fed907ee6670526694a0680,
+        ns26:bd63fe69-25df-4b36-a4f0-c7b87157a89b ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a0657> ;
+    ns22:qualifiedInvalidation ns25:5fed907ee6670526694a0683 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0652> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a068a> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ee6670526694a068a" ;
+    skos:prefLabel "Bourgeois I" ;
+    ns22:hadMember ns26:5fed907ee6670526694a068b,
+        ns26:5fed907ee6670526694a068d,
+        ns26:5fed907ee6670526694a068e,
+        ns26:5fed907ee6670526694a068f,
+        ns26:5fed907ee6670526694a0691,
+        ns26:5fed907ee6670526694a0692,
+        ns26:5fed907ee6670526694a0694,
+        ns26:5fed907ee6670526694a0696,
+        ns26:5fed907ee6670526694a0698,
+        ns26:5fed907ee6670526694a069a,
+        ns26:5fed907ee6670526694a069b,
+        ns26:5fed907ee6670526694a069c,
+        ns26:5fed907ee6670526694a069f,
+        ns26:5fed907ee6670526694a06a1,
+        ns26:5fed907ee6670526694a06a2,
+        ns26:5fed907ee6670526694a06a3,
+        ns26:5fed907ee6670526694a06a4,
+        ns26:5fed907ee6670526694a06a5,
+        ns26:5fed907ee6670526694a06a6,
+        ns26:5fed907ee6670526694a06a7,
+        ns26:5fed907ee6670526694a06a8,
+        ns26:5fed907ee6670526694a06a9,
+        ns26:5fed907ee6670526694a06aa,
+        ns26:5fed907ee6670526694a06ab,
+        ns26:5fed907ee6670526694a06ac,
+        ns26:5fed907ee6670526694a06ad,
+        ns26:5fed907ee6670526694a06ae,
+        ns26:5fed907ee6670526694a06af,
+        ns26:5fed907ee6670526694a06b1,
+        ns26:5fed907ee6670526694a06b2,
+        ns26:5fed907ee6670526694a06b3,
+        ns26:5fed907ee6670526694a06b4,
+        ns26:5fed907ee6670526694a06b5,
+        ns26:5fed907ee6670526694a06b6,
+        ns26:5fed907ee6670526694a06b7,
+        ns26:5fed907ee6670526694a06b8,
+        ns26:5fed907ee6670526694a06b9,
+        ns26:5fed907ee6670526694a06ba,
+        ns26:5fed907ee6670526694a06bb,
+        ns26:5fed907ee6670526694a06bc,
+        ns26:5fed907ee6670526694a06bd,
+        ns26:5fed907ee6670526694a06be,
+        ns26:5fed907ee6670526694a06bf,
+        ns26:5fed907ee6670526694a06c0,
+        ns26:5fed907ee6670526694a06c1,
+        ns26:5fed907ee6670526694a06c2,
+        ns26:5fed907ee6670526694a06c3,
+        ns26:5fed907ee6670526694a06c4,
+        ns26:5fed907ee6670526694a06c5,
+        ns26:5fed907ee6670526694a06c6,
+        ns26:5fed907ee6670526694a06c7,
+        ns26:5fed907ee6670526694a06c8,
+        ns26:5fed907ee6670526694a06c9,
+        ns26:5fed907ee6670526694a06ca,
+        ns26:5fed907ee6670526694a06cb,
+        ns26:5fed907ee6670526694a06cc,
+        ns26:5fed907ee6670526694a06cd,
+        ns26:5fed907ee6670526694a06ce,
+        ns26:5fed907ee6670526694a06cf,
+        ns26:5fed907ee6670526694a06d0,
+        ns26:5fed907ee6670526694a06d1,
+        ns26:5fed907ee6670526694a06d3,
+        ns26:5fed907ee6670526694a06d4,
+        ns26:5fed907ee6670526694a06d5,
+        ns26:5fed907ee6670526694a06d6,
+        ns26:5fed907ee6670526694a06d7,
+        ns26:5fed907ee6670526694a06d8,
+        ns26:5fed907ee6670526694a06d9,
+        ns26:5fed907ee6670526694a06da,
+        ns26:5fed907ee6670526694a06db,
+        ns26:5fed907ee6670526694a06dc,
+        ns26:5fed907ee6670526694a06dd,
+        ns26:5fed907ee6670526694a06de,
+        ns26:5fed907ee6670526694a06df,
+        ns26:5fed907ee6670526694a06e1 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a0689> ;
+    ns22:qualifiedInvalidation ns25:3e2de57a-ad83-4462-8a3f-efb5071af8f9 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0684> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a06e3> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ee6670526694a06e3" ;
+    skos:prefLabel "Homans I" ;
+    ns22:hadMember ns26:5fed907ee6670526694a06e4,
+        ns26:5fed907ee6670526694a06e5,
+        ns26:5fed907ee6670526694a06e6,
+        ns26:5fed907ee6670526694a06e7,
+        ns26:5fed907ee6670526694a06e8,
+        ns26:5fed907ee6670526694a06e9,
+        ns26:5fed907ee6670526694a06ea,
+        ns26:5fed907ee6670526694a06eb,
+        ns26:5fed907ee6670526694a06ec,
+        ns26:5fed907ee6670526694a06ed,
+        ns26:5fed907ee6670526694a06ee,
+        ns26:5fed907ee6670526694a06f0,
+        ns26:5fed907ee6670526694a06f1,
+        ns26:5fed907ee6670526694a06f2,
+        ns26:5fed907ee6670526694a06f3,
+        ns26:5fed907ee6670526694a06f4,
+        ns26:5fed907ee6670526694a06f5,
+        ns26:5fed907ee6670526694a06f6,
+        ns26:5fed907ee6670526694a06f7,
+        ns26:5fed907ee6670526694a06f8,
+        ns26:5fed907ee6670526694a06f9,
+        ns26:5fed907ee6670526694a06fa,
+        ns26:5fed907ee6670526694a06fb,
+        ns26:5fed907ee6670526694a06fc ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a06e2> ;
+    ns22:qualifiedInvalidation ns25:5fed907ee6670526694a06ff ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0684> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0706> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ee6670526694a0706" ;
+    skos:prefLabel "Jambon" ;
+    ns22:hadMember ns26:1e207740-3834-4e98-8431-5a2c08704516,
+        ns26:3dc729d9-94b7-41f7-8c91-cc30951d6a56,
+        ns26:5678ff3c-ef96-4d19-b5a9-b383adcc69aa,
+        ns26:5deb9bb2-204a-4fbe-93ba-edeb5fa7a57b,
+        ns26:5fed907ee6670526694a0708,
+        ns26:5fed907ee6670526694a070c,
+        ns26:5fed907ee6670526694a070d,
+        ns26:5fed907ee6670526694a070f,
+        ns26:5fed907ee6670526694a0710,
+        ns26:5fed907ee6670526694a0711,
+        ns26:5fed907ee6670526694a0712,
+        ns26:5fed907ee6670526694a0713,
+        ns26:5fed907ee6670526694a0715,
+        ns26:5fed907ee6670526694a0719,
+        ns26:5fed907ee6670526694a071b,
+        ns26:5fed907ee6670526694a071c,
+        ns26:5fed907ee6670526694a071e,
+        ns26:74cf5db5-8b6c-442e-baf4-97fbc896f986,
+        ns26:81e6ca1b-97c1-4572-ae79-fba4ccb91e91,
+        ns26:a390a4fb-1be7-4128-afd0-e38da7883e5d,
+        ns26:cabd47da-7956-4c21-83b3-539fd0f4a4de,
+        ns26:d437d986-09de-4b46-8fce-f6ca4389f492,
+        ns26:d89222e1-eb8a-411f-8889-b1c1b688ab90,
+        ns26:dc380cfb-3987-42bb-afc6-8e079e64ff63,
+        ns26:dc66d32b-be05-43b8-ac18-0d91fdf8c6ec,
+        ns26:e2242233-4b72-4079-bb20-d196da78edbb,
+        ns27:145bafde-10ea-4a73-8fe9-042cdea3ccbe,
+        ns27:14d57d14-5922-4a7b-8574-1b682df71145,
+        ns27:1c62a2f3-cc0c-4760-ada9-90c7f879369e,
+        ns27:34405d19-996f-4f9e-8616-a30e6f3a1175,
+        ns27:38e5e0e9-52c7-4f7d-b92b-16eee0edd193,
+        ns27:43c129cc-ba12-4457-b93e-737b7370c46e,
+        ns27:488d5ce1-bed5-400c-985a-734ff6e296f5,
+        ns27:4eae2f7e-ca9f-42d6-abed-dcd4ab56fd65,
+        ns27:6ace9621-2236-4023-b77d-f4cb8dec1565,
+        ns27:758e0782-fa7e-4740-a5fa-032e4c0d04ca,
+        ns27:7c4c08aa-b058-4656-8aac-cd9946cbeac3,
+        ns27:8d2639a1-afca-467c-b7a8-9ba01fa54852,
+        ns27:8dcdc330-348d-4f69-b10c-02f584adb9af,
+        ns27:a55415f4-a212-4ff0-b8e6-3bc1799361af,
+        ns27:aa642a1e-7cc4-44da-9a6b-bce625761c5f,
+        ns27:b374d85b-428d-4177-910d-0f7077cb3311,
+        ns27:bb2e174a-374e-447d-ad0c-002204b4561f,
+        ns27:c665812d-820d-4f77-a559-e8c757a82302,
+        ns27:d283fd40-f781-4300-a913-60658e2aec85,
+        ns27:d7593ea4-a74d-403d-beeb-8f9ed0fbb082,
+        ns27:ddcf86cf-387e-4afc-a38f-2e183ce46909,
+        ns27:e6652d4d-418b-4060-b309-084d6f0a60fe,
+        ns27:e8706d05-70b7-4b5c-ba75-f07c56cb259f,
+        ns27:e92489ff-126c-4569-a15e-ae8e193be345,
+        ns27:f7fe3320-7c15-4322-b907-02571d3dfe6e ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a0705> ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0700> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/60d0dc2ab1838d01fca7db70> a ns11:Bestuursorgaan ;
+    ns3:uuid "60d0dc2ab1838d01fca7db70" ;
+    skos:prefLabel "Van den Brande I (VR)" ;
+    ns22:hadMember ns26:5fed907ce6670526694a04be,
+        ns26:5fed907ce6670526694a04bf,
+        ns26:5fed907ce6670526694a04c0,
+        ns26:5fed907ce6670526694a04c1,
+        ns26:5fed907ce6670526694a04c2,
+        ns26:5fed907ce6670526694a04c3,
+        ns26:5fed907ce6670526694a04c4,
+        ns26:5fed907ce6670526694a04c5,
+        ns26:5fed907ce6670526694a04c6,
+        ns26:5fed907ce6670526694a04c8,
+        ns26:5fed907ce6670526694a04c9,
+        ns26:5fed907ce6670526694a04ca,
+        ns26:5fed907ce6670526694a04cb,
+        ns26:5fed907ce6670526694a04cc,
+        ns26:5fed907ce6670526694a04cd,
+        ns26:5fed907ce6670526694a04ce,
+        ns26:5fed907ce6670526694a04cf,
+        ns26:5fed907ce6670526694a04d0,
+        ns26:5fed907ce6670526694a04d1,
+        ns26:5fed907ce6670526694a04d2,
+        ns26:5fed907de6670526694a04d3,
+        ns26:5fed907de6670526694a04d4,
+        ns26:5fed907de6670526694a04d5,
+        ns26:5fed907de6670526694a04d6,
+        ns26:5fed907de6670526694a04d7,
+        ns26:5fed907de6670526694a04d8,
+        ns26:5fed907de6670526694a04d9,
+        ns26:5fed907de6670526694a04da,
+        ns26:5fed907de6670526694a04dc,
+        ns26:5fed907de6670526694a04dd,
+        ns26:5fed907de6670526694a04de,
+        ns26:5fed907de6670526694a04df,
+        ns26:5fed907de6670526694a04e0,
+        ns26:5fed907de6670526694a04e1,
+        ns26:5fed907de6670526694a04e2,
+        ns26:5fed907de6670526694a04e3,
+        ns26:5fed907de6670526694a04e4 ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/60d0dc2ab1838d01fca7db6e> ;
+    ns22:qualifiedInvalidation ns25:60d0dc2ab1838d01fca7db6f ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a0499> .
+
+ns1:5fed907ce6670526694a03e2 a skos:ConceptScheme ;
+    ns3:uuid "5fed907ce6670526694a03e2" ;
+    skos:prefLabel "Beleidsdomeinen concept scheme" .
+
+ns13:fb1916be-0a42-4a52-a69d-92764eba4955 a skos:Concept ;
+    ns3:uuid "fb1916be-0a42-4a52-a69d-92764eba4955" ;
+    skos:inScheme ns1:eabe9bb8-d4e1-409e-9132-2d09e5a89bef ;
+    skos:prefLabel "Publieke vrijgave" .
+
+ns5:b3d8a99b-0a7e-419e-8474-4b508fa7ab91 a skos:Concept ;
+    ns3:uuid "b3d8a99b-0a7e-419e-8474-4b508fa7ab91" ;
+    skos:inScheme ns1:b4470852-7799-42a1-af8f-22d15088ba16 ;
+    skos:prefLabel "Ontwerp" .
+
+ns5:dce8eb02-fa3b-44bc-aa48-2ff7eec21a74 a skos:Concept ;
+    ns3:uuid "dce8eb02-fa3b-44bc-aa48-2ff7eec21a74" ;
+    skos:inScheme ns1:b4470852-7799-42a1-af8f-22d15088ba16 ;
+    skos:prefLabel "Afgesloten" .
+
+ns5:de6fc320-cfb9-47a6-af25-e063b80992f7 a skos:Concept ;
+    ns3:uuid "de6fc320-cfb9-47a6-af25-e063b80992f7" ;
+    skos:inScheme ns1:b4470852-7799-42a1-af8f-22d15088ba16 ;
+    skos:prefLabel "Publiek" .
+
+ns5:fff6627e-4c96-4be1-b483-8fefcc6523ca a skos:Concept ;
+    ns3:uuid "fff6627e-4c96-4be1-b483-8fefcc6523ca" ;
+    skos:inScheme ns1:b4470852-7799-42a1-af8f-22d15088ba16 ;
+    skos:prefLabel "Goedgekeurd" .
+
+ns7:8f8adcf0-58ef-4edc-9e36-0c9095fd76b0 a skos:Concept ;
+    ns3:uuid "8f8adcf0-58ef-4edc-9e36-0c9095fd76b0" ;
+    skos:inScheme ns1:55c9120c-6a3d-49c4-80c8-ed01e9b92a9b ;
+    skos:prefLabel "Mededeling" .
+
+ns7:dd47a8f8-3ad2-4d5a-8318-66fc02fe80fd a skos:Concept ;
+    ns3:uuid "dd47a8f8-3ad2-4d5a-8318-66fc02fe80fd" ;
+    skos:inScheme ns1:55c9120c-6a3d-49c4-80c8-ed01e9b92a9b ;
+    skos:prefLabel "Nota" .
+
+<http://themis.vlaanderen.be/id/concept/dataset-type/43c644d3-2171-4892-8dd7-3fd5eec15d09> a skos:Concept ;
+    ns3:uuid "43c644d3-2171-4892-8dd7-3fd5eec15d09" ;
+    skos:definition "Samenstelling van de Vlaamse Regering uit heden en verleden. Dit omvat bestuursorganen, legislaturen, mandaten, mandatarissen en personen." ;
+    skos:inScheme ns1:e93481b2-342d-468b-8def-2d629232d3a5 ;
+    skos:prefLabel "Samenstelling Vlaamse Regering" .
+
+<http://themis.vlaanderen.be/id/concept/dataset-type/49e2bdc1-6c32-4021-b12b-2c9ff3674cd1> a skos:Concept ;
+    ns3:uuid "49e2bdc1-6c32-4021-b12b-2c9ff3674cd1" ;
+    skos:definition "Gecontroleerde lijsten van concepten gegroepeerd in concept schemes (vb. type documenten, thema's, ...)" ;
+    skos:inScheme ns1:e93481b2-342d-468b-8def-2d629232d3a5 ;
+    skos:prefLabel "Codelijst / concept scheme" .
+
+<http://themis.vlaanderen.be/id/concept/dataset-type/5d8b757f-76f4-4aaa-a2dc-4bc6c9876560> a skos:Concept ;
+    ns3:uuid "5d8b757f-76f4-4aaa-a2dc-4bc6c9876560" ;
+    skos:definition "Alle stukken van een dossier met de bijhorende procedurestappen die het dossier doorlopen heeft" ;
+    skos:inScheme ns1:e93481b2-342d-468b-8def-2d629232d3a5 ;
+    skos:prefLabel "Levensboom van een dossier" .
+
+<http://themis.vlaanderen.be/id/concept/dataset-type/9119805f-9ee6-4ef1-9ef7-ad8dccc2bf2d> a skos:Concept ;
+    ns3:uuid "9119805f-9ee6-4ef1-9ef7-ad8dccc2bf2d" ;
+    skos:definition "Verslag van een vergaderactiviteit (bvb. een ministerraad) in kort bestek. Dit omvat een nieuwsbericht voor elke publieke beslissing/mededeling, eventueel met bijhorende bijlagen." ;
+    skos:inScheme ns1:e93481b2-342d-468b-8def-2d629232d3a5 ;
+    skos:prefLabel "Vergaderactiviteit in kort bestek" .
+
+ns4:c4d99dde-3df9-4da1-8136-9a3b2de82de4 a skos:Concept ;
+    ns3:uuid "c4d99dde-3df9-4da1-8136-9a3b2de82de4" ;
+    skos:inScheme ns1:f27ae84d-fded-4ea5-a8f8-f4b98664214b ;
+    skos:prefLabel "Bijlage bij nieuwsbericht" .
+
+ns4:dd5bfc23-8f88-4df5-80f6-a9f72e08d7c4 a skos:Concept ;
+    ns3:uuid "dd5bfc23-8f88-4df5-80f6-a9f72e08d7c4" ;
+    skos:inScheme ns1:f27ae84d-fded-4ea5-a8f8-f4b98664214b ;
+    skos:prefLabel "Nieuwsberichten" .
+
+ns6:0ed0785c-f427-4bc0-8507-72eb2a7b5454 a skos:Concept ;
+    ns3:uuid "0ed0785c-f427-4bc0-8507-72eb2a7b5454" ;
+    skos:altLabel "Samenwerkingsakkoord" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "SWA" .
+
+ns6:126f7ca5-c1e8-458a-80c2-38828a6010cc a skos:Concept ;
+    ns3:uuid "126f7ca5-c1e8-458a-80c2-38828a6010cc" ;
+    skos:altLabel "Groenboek" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Groenboek" .
+
+ns6:1e254f84-d442-425e-9fc9-5ac552b9d089 a skos:Concept ;
+    ns3:uuid "1e254f84-d442-425e-9fc9-5ac552b9d089" ;
+    skos:altLabel "Bijlage ter beslissing" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "BijlageNota" .
+
+ns6:25b58316-50f2-411c-9012-e4e1957b1750 a skos:Concept ;
+    ns3:uuid "25b58316-50f2-411c-9012-e4e1957b1750" ;
+    skos:altLabel "Besluit van een secretaris-generaal" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Besluit SG" .
+
+ns6:2c18bb9d-bbfe-474a-9f81-63ba3983a33e a skos:Concept ;
+    ns3:uuid "2c18bb9d-bbfe-474a-9f81-63ba3983a33e" ;
+    skos:altLabel "Voorontwerp van decreet" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "VOD" .
+
+ns6:2f331ce0-70e7-4150-b317-d2dbf52d6251 a skos:Concept ;
+    ns3:uuid "2f331ce0-70e7-4150-b317-d2dbf52d6251" ;
+    skos:altLabel "Agenda" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Agenda" .
+
+ns6:2fef8c6a-ca60-4cd5-97b3-578144aece0a a skos:Concept ;
+    ns3:uuid "2fef8c6a-ca60-4cd5-97b3-578144aece0a" ;
+    skos:altLabel "Resolutie" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Resolutie" .
+
+ns6:351ba62d-eeff-4b08-b1e3-0a56d38116c4 a skos:Concept ;
+    ns3:uuid "351ba62d-eeff-4b08-b1e3-0a56d38116c4" ;
+    skos:altLabel "Advies van Inspectie Financiën" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "IF" .
+
+ns6:361f3132-d763-412d-8d16-609ad664055c a skos:Concept ;
+    ns3:uuid "361f3132-d763-412d-8d16-609ad664055c" ;
+    skos:altLabel "Witboek" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Witboek" .
+
+ns6:3f6ed920-7cd0-4296-a5b7-eb06d77ca5f4 a skos:Concept ;
+    ns3:uuid "3f6ed920-7cd0-4296-a5b7-eb06d77ca5f4" ;
+    skos:altLabel "Voorontwerp van BVR" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "VOBVR" .
+
+ns6:53aea93f-c0f7-4a9e-a5b3-5d683ccf783c a skos:Concept ;
+    ns3:uuid "53aea93f-c0f7-4a9e-a5b3-5d683ccf783c" ;
+    skos:altLabel "Beleidsnota" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Beleidsnota" .
+
+ns6:59b81be7-26c9-4a08-9a51-ce23ce83a133 a skos:Concept ;
+    ns3:uuid "59b81be7-26c9-4a08-9a51-ce23ce83a133" ;
+    skos:altLabel "Verslag aan de Regering" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Verslag" .
+
+ns6:5c8689fc-af45-480e-b16a-ec1e61680acd a skos:Concept ;
+    ns3:uuid "5c8689fc-af45-480e-b16a-ec1e61680acd" ;
+    skos:altLabel "Besluit Afdelingshoofd" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Besluit AH" .
+
+ns6:63d628cb-a594-4166-8b4e-880b4214fc5b a skos:Concept ;
+    ns3:uuid "63d628cb-a594-4166-8b4e-880b4214fc5b" ;
+    skos:altLabel "Beslissing in kort bestek" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Nieuwsbericht" .
+
+ns6:6870daa2-d80a-4483-a78f-53cbd6b85af2 a skos:Concept ;
+    ns3:uuid "6870daa2-d80a-4483-a78f-53cbd6b85af2" ;
+    skos:altLabel "Begrotingsakkoord van de minister van begroting" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "BA" .
+
+ns6:6b4e9376-449a-43f8-8027-6dc63494057b a skos:Concept ;
+    ns3:uuid "6b4e9376-449a-43f8-8027-6dc63494057b" ;
+    skos:altLabel "Proces Verbaal" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "PV" .
+
+ns6:728b0691-c89b-4569-b570-4793f31b7100 a skos:Concept ;
+    ns3:uuid "728b0691-c89b-4569-b570-4793f31b7100" ;
+    skos:altLabel "Arrest" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Arrest" .
+
+ns6:72dd647f-7afa-4d2a-9c7f-de73a8bd85a1 a skos:Concept ;
+    ns3:uuid "72dd647f-7afa-4d2a-9c7f-de73a8bd85a1" ;
+    skos:altLabel "Mededeling" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Mededeling" .
+
+ns6:73d69df5-c3f3-43b2-aeae-5a24b56b376e a skos:Concept ;
+    ns3:uuid "73d69df5-c3f3-43b2-aeae-5a24b56b376e" ;
+    skos:altLabel "Advies Raad van State" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "RvS" .
+
+ns6:7b8cc610-2bcd-4eab-afa2-8cd7adbd4d4f a skos:Concept ;
+    ns3:uuid "7b8cc610-2bcd-4eab-afa2-8cd7adbd4d4f" ;
+    skos:altLabel "Motie" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Motie" .
+
+ns6:7ef77ae1-816b-4eba-bae8-1f7d73cd7cba a skos:Concept ;
+    ns3:uuid "7ef77ae1-816b-4eba-bae8-1f7d73cd7cba" ;
+    skos:altLabel "Conceptnota" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Concept" .
+
+ns6:83888ef0-a44a-4abf-a977-acfcfa63ed8b a skos:Concept ;
+    ns3:uuid "83888ef0-a44a-4abf-a977-acfcfa63ed8b" ;
+    skos:altLabel "Besluit Hoofd Departement" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Besluit HD" .
+
+ns6:83f7dc8b-b763-47c4-8a21-f7e43b879ad2 a skos:Concept ;
+    ns3:uuid "83f7dc8b-b763-47c4-8a21-f7e43b879ad2" ;
+    skos:altLabel "Samenwerkingsovereenkomst" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "SWO" .
+
+ns6:8864821b-0eb8-42c6-99db-e39f20e9de10 a skos:Concept ;
+    ns3:uuid "8864821b-0eb8-42c6-99db-e39f20e9de10" ;
+    skos:altLabel "Besluit Hoofd Agentschap" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Besluit HA" .
+
+ns6:8a1e048a-4b55-4a19-b1c0-c85dba09a15c a skos:Concept ;
+    ns3:uuid "8a1e048a-4b55-4a19-b1c0-c85dba09a15c" ;
+    skos:altLabel "Ontwerpdecreet van Vlaamse Regering" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "OD" .
+
+ns6:8ae796bd-690a-4ed6-855c-c4572e883066 a skos:Concept ;
+    ns3:uuid "8ae796bd-690a-4ed6-855c-c4572e883066" ;
+    skos:altLabel "Visienota" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Visienota" .
+
+ns6:9c043848-6a9f-4448-9794-600e40dee6d2 a skos:Concept ;
+    ns3:uuid "9c043848-6a9f-4448-9794-600e40dee6d2" ;
+    skos:altLabel "Advies agentschap overheidspersoneel" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Advies AgO" .
+
+ns6:a270ebff-2883-4c96-95c7-64fa89a729c5 a skos:Concept ;
+    ns3:uuid "a270ebff-2883-4c96-95c7-64fa89a729c5" ;
+    skos:altLabel "Bijlage(n) ter informatie" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "BijlageInfo" .
+
+ns6:a354eebe-43d2-43b9-a018-483b3cd605ea a skos:Concept ;
+    ns3:uuid "a354eebe-43d2-43b9-a018-483b3cd605ea" ;
+    skos:altLabel "Erratum" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Errat" .
+
+ns6:b3e150d3-eac6-44cf-9e70-dd4d13423631 a skos:Concept ;
+    ns3:uuid "b3e150d3-eac6-44cf-9e70-dd4d13423631" ;
+    skos:altLabel "Bijlage" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Bijlage" .
+
+ns6:bcbd33f1-f058-46d0-9c53-569edd5dbede a skos:Concept ;
+    ns3:uuid "bcbd33f1-f058-46d0-9c53-569edd5dbede" ;
+    skos:altLabel "Besluit van een administrateur-generaal" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Besluit AG" .
+
+ns6:cc9b4207-43da-4394-94d7-3be051aa95e7 a skos:Concept ;
+    ns3:uuid "cc9b4207-43da-4394-94d7-3be051aa95e7" ;
+    skos:altLabel "Akkoord Bestuurszaken" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Akkoord BZ" .
+
+ns6:cf471294-af65-455c-a200-86b7fd70751a a skos:Concept ;
+    ns3:uuid "cf471294-af65-455c-a200-86b7fd70751a" ;
+    skos:altLabel "Overeenkomst" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Overeenkomst" .
+
+ns6:d3a616a1-4734-409d-be51-30917c91eb84 a skos:Concept ;
+    ns3:uuid "d3a616a1-4734-409d-be51-30917c91eb84" ;
+    skos:altLabel "Ontwerp van BVR" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "OBVR" .
+
+ns6:d638e0dc-c879-4a75-9485-9e6970a83d67 a skos:Concept ;
+    ns3:uuid "d638e0dc-c879-4a75-9485-9e6970a83d67" ;
+    skos:altLabel "Notulen" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Notulen" .
+
+ns6:e807feec-1958-46cf-a558-3379b5add49e a skos:Concept ;
+    ns3:uuid "e807feec-1958-46cf-a558-3379b5add49e" ;
+    skos:altLabel "Beslissingsfiche" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "BF" .
+
+ns6:e87f3a3a-d4dd-4560-8834-024b1e27a374 a skos:Concept ;
+    ns3:uuid "e87f3a3a-d4dd-4560-8834-024b1e27a374" ;
+    skos:altLabel "Bericht" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Bericht" .
+
+ns6:e9e8ec50-c6fd-44ac-bc34-e5e4cdb0294e a skos:Concept ;
+    ns3:uuid "e9e8ec50-c6fd-44ac-bc34-e5e4cdb0294e" ;
+    skos:altLabel "Omzendbrief" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "OMZ" .
+
+ns6:eb048853-dc2e-44f8-9bf1-f0b7a7460a4d a skos:Concept ;
+    ns3:uuid "eb048853-dc2e-44f8-9bf1-f0b7a7460a4d" ;
+    skos:altLabel "Besluit Raad van Bestuur" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Besluit RvB" .
+
+ns6:f036e016-268e-4611-8fee-77d2047b51d8 a skos:Concept ;
+    ns3:uuid "f036e016-268e-4611-8fee-77d2047b51d8" ;
+    skos:altLabel "Memorie van Toelichting" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "MvT" .
+
+ns6:f2b0f655-8ed7-4f61-8f2b-ca813de7a6ed a skos:Concept ;
+    ns3:uuid "f2b0f655-8ed7-4f61-8f2b-ca813de7a6ed" ;
+    skos:altLabel "Nota aan de Vlaamse Regering" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Nota" .
+
+ns6:fb931eff-38f2-4743-802b-4240c35b8b0c a skos:Concept ;
+    ns3:uuid "fb931eff-38f2-4743-802b-4240c35b8b0c" ;
+    skos:altLabel "Advies" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Advies" .
+
+ns6:fbd697b7-9857-477f-8725-d6856a563f7a a skos:Concept ;
+    ns3:uuid "fbd697b7-9857-477f-8725-d6856a563f7a" ;
+    skos:altLabel "Beleidsbrief" ;
+    skos:inScheme ns1:559774e3-061c-4f4b-a758-57228d4b68cd ;
+    skos:prefLabel "Beleidsbrief" .
+
+ns16:026d2ff8-27ac-4f37-9aaa-d0093ad7186b a skos:Concept ;
+    ns3:uuid "026d2ff8-27ac-4f37-9aaa-d0093ad7186b" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Onroerend Erfgoed" .
+
+ns16:03c150a0-0280-474c-be06-2d1bf46d7aa9 a skos:Concept ;
+    ns3:uuid "03c150a0-0280-474c-be06-2d1bf46d7aa9" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Vlaanderen" .
+
+ns16:0af76a98-8291-404f-b457-67cdecb9e2ab a skos:Concept ;
+    ns3:uuid "0af76a98-8291-404f-b457-67cdecb9e2ab" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Belastingen" .
+
+ns16:0cc58cdc-dcf4-4d6c-bc9e-27ea721baf25 a skos:Concept ;
+    ns3:uuid "0cc58cdc-dcf4-4d6c-bc9e-27ea721baf25" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Binnenlandse Aangelegenheden" .
+
+ns16:0eea2c46-f75a-4148-9020-b10dd613b674 a skos:Concept ;
+    ns3:uuid "0eea2c46-f75a-4148-9020-b10dd613b674" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Internationaal Ondernemen" .
+
+ns16:1034e201-ba90-44db-bd6e-e99b21111dfe a skos:Concept ;
+    ns3:uuid "1034e201-ba90-44db-bd6e-e99b21111dfe" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Landbouw" .
+
+ns16:11f2a96c-f551-4edd-98d4-f55cbaa6e222 a skos:Concept ;
+    ns3:uuid "11f2a96c-f551-4edd-98d4-f55cbaa6e222" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Dierenwelzijn" .
+
+ns16:1229a139-cd06-4ba7-9998-da34bf46ed6d a skos:Concept ;
+    ns3:uuid "1229a139-cd06-4ba7-9998-da34bf46ed6d" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Milieu" .
+
+ns16:12f19487-9fc6-4c02-afc3-0015b1127144 a skos:Concept ;
+    ns3:uuid "12f19487-9fc6-4c02-afc3-0015b1127144" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Media" .
+
+ns16:17ddaff0-b2e3-4f02-9157-76a1cf593a5b a skos:Concept ;
+    ns3:uuid "17ddaff0-b2e3-4f02-9157-76a1cf593a5b" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Mobiliteit" .
+
+ns16:17fc23af-a51b-46eb-a299-3208ce2b3558 a skos:Concept ;
+    ns3:uuid "17fc23af-a51b-46eb-a299-3208ce2b3558" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Europese Instellingen" .
+
+ns16:197aa946-5676-4a39-8c7b-56256630711f a skos:Concept ;
+    ns3:uuid "197aa946-5676-4a39-8c7b-56256630711f" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Visserij" .
+
+ns16:233a8980-9982-445e-8542-8ef7f06797ff a skos:Concept ;
+    ns3:uuid "233a8980-9982-445e-8542-8ef7f06797ff" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Toerisme" .
+
+ns16:2de782cb-3c14-4e2d-9c2d-7d25428fa7d6 a skos:Concept ;
+    ns3:uuid "2de782cb-3c14-4e2d-9c2d-7d25428fa7d6" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Justitie" .
+
+ns16:2ef1a01c-861b-449a-9c7b-e0efd324a7d2 a skos:Concept ;
+    ns3:uuid "2ef1a01c-861b-449a-9c7b-e0efd324a7d2" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Justitie en Handhaving" .
+
+ns16:30354d68-91c8-47b0-b5ba-6418d261f642 a skos:Concept ;
+    ns3:uuid "30354d68-91c8-47b0-b5ba-6418d261f642" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Welzijn" .
+
+ns16:34394a01-5c8c-44c9-aade-59087026f266 a skos:Concept ;
+    ns3:uuid "34394a01-5c8c-44c9-aade-59087026f266" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Inburgering" .
+
+ns16:34654906-74bd-4a69-9f93-0971f263cca3 a skos:Concept ;
+    ns3:uuid "34654906-74bd-4a69-9f93-0971f263cca3" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Jeugd" .
+
+ns16:45cfa0c9-82db-4487-8ad4-ca21fa6655ab a skos:Concept ;
+    ns3:uuid "45cfa0c9-82db-4487-8ad4-ca21fa6655ab" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Energie" .
+
+ns16:49dbc623-7e91-4a52-8d98-13f8db271eb5 a skos:Concept ;
+    ns3:uuid "49dbc623-7e91-4a52-8d98-13f8db271eb5" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Overheidsinvesteringen" .
+
+ns16:4a0bb077-a416-4e4d-96ce-b2e89cec0a47 a skos:Concept ;
+    ns3:uuid "4a0bb077-a416-4e4d-96ce-b2e89cec0a47" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Welzijn en Gezondheid" .
+
+ns16:4dfb835d-ded2-4298-85bb-ff41f3563193 a skos:Concept ;
+    ns3:uuid "4dfb835d-ded2-4298-85bb-ff41f3563193" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Gelijke kansen" .
+
+ns16:564568e3-aad3-4940-9640-6cf00a326a10 a skos:Concept ;
+    ns3:uuid "564568e3-aad3-4940-9640-6cf00a326a10" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Ontwikkelingssamenwerking" .
+
+ns16:5a97037d-b260-4d32-827d-cb9c7360454d a skos:Concept ;
+    ns3:uuid "5a97037d-b260-4d32-827d-cb9c7360454d" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Criminaliteit" .
+
+ns16:5ae2b345-3a34-422c-9ee5-a90927fd2158 a skos:Concept ;
+    ns3:uuid "5ae2b345-3a34-422c-9ee5-a90927fd2158" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Cultuur" .
+
+ns16:5f16f346-a0da-484f-af7d-9fb54d4bd9d2 a skos:Concept ;
+    ns3:uuid "5f16f346-a0da-484f-af7d-9fb54d4bd9d2" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Volksgezondheid" .
+
+ns16:6053f77e-09d3-4d08-8b1e-1fc5f34f3667 a skos:Concept ;
+    ns3:uuid "6053f77e-09d3-4d08-8b1e-1fc5f34f3667" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Financiën" .
+
+ns16:610ed51e-6b20-4171-9a83-eedc6eabf7e6 a skos:Concept ;
+    ns3:uuid "610ed51e-6b20-4171-9a83-eedc6eabf7e6" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Werk" .
+
+ns16:63aa8960-a301-40b4-9bba-7cfed45f0494 a skos:Concept ;
+    ns3:uuid "63aa8960-a301-40b4-9bba-7cfed45f0494" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Openbare Werken" .
+
+ns16:64b1d7a3-be0a-4f7e-8768-674182756c9e a skos:Concept ;
+    ns3:uuid "64b1d7a3-be0a-4f7e-8768-674182756c9e" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Erfgoed" .
+
+ns16:6af19df8-a1e9-43bc-85f4-3cf8ac151d7e a skos:Concept ;
+    ns3:uuid "6af19df8-a1e9-43bc-85f4-3cf8ac151d7e" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Armoedebestrijding" .
+
+ns16:6b4bf676-b4ef-474e-b650-1115ebd23376 a skos:Concept ;
+    ns3:uuid "6b4bf676-b4ef-474e-b650-1115ebd23376" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Vlaamse Rand" .
+
+ns16:6c739358-33b7-4f18-9eb8-eb956580b4ae a skos:Concept ;
+    ns3:uuid "6c739358-33b7-4f18-9eb8-eb956580b4ae" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Klimaat" .
+
+ns16:724707d5-a6b5-4c3c-8dea-76422f2c0975 a skos:Concept ;
+    ns3:uuid "724707d5-a6b5-4c3c-8dea-76422f2c0975" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Zorg" .
+
+ns16:742ff0f0-1514-4b0b-a799-0248ba00fbb7 a skos:Concept ;
+    ns3:uuid "742ff0f0-1514-4b0b-a799-0248ba00fbb7" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Inburgering en Integratie" .
+
+ns16:758c3c7d-5b60-4eff-9320-2431a3120d19 a skos:Concept ;
+    ns3:uuid "758c3c7d-5b60-4eff-9320-2431a3120d19" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Leefmilieu en Natuur" .
+
+ns16:7fd362b0-4580-4f85-b046-4b62f212f4b6 a skos:Concept ;
+    ns3:uuid "7fd362b0-4580-4f85-b046-4b62f212f4b6" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Begroting en Financiën" .
+
+ns16:8520696c-6434-4361-b1c6-50f1498af60a a skos:Concept ;
+    ns3:uuid "8520696c-6434-4361-b1c6-50f1498af60a" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Gezin" .
+
+ns16:872c910d-dd86-46b4-a3b0-0ff45df32702 a skos:Concept ;
+    ns3:uuid "872c910d-dd86-46b4-a3b0-0ff45df32702" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Landbouw en Visserij" .
+
+ns16:8b064325-83ad-4083-8781-4687fb8f7b15 a skos:Concept ;
+    ns3:uuid "8b064325-83ad-4083-8781-4687fb8f7b15" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Bouwen" .
+
+ns16:8fe54f8f-c83a-436d-8234-e683fccae582 a skos:Concept ;
+    ns3:uuid "8fe54f8f-c83a-436d-8234-e683fccae582" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Sociale Economie" .
+
+ns16:91b7d388-3260-4444-90ca-9b08f612dfe4 a skos:Concept ;
+    ns3:uuid "91b7d388-3260-4444-90ca-9b08f612dfe4" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Ruimtelijke Ordening" .
+
+ns16:97028dc8-9a4a-466f-a9b9-244bae08221e a skos:Concept ;
+    ns3:uuid "97028dc8-9a4a-466f-a9b9-244bae08221e" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Natuurlijke Rijkdommen" .
+
+ns16:97291d01-e7f3-46a2-86b1-4d5997b41de7 a skos:Concept ;
+    ns3:uuid "97291d01-e7f3-46a2-86b1-4d5997b41de7" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Digitale agenda" .
+
+ns16:9d82e85b-a02c-4bf0-b324-1eb0b5e81042 a skos:Concept ;
+    ns3:uuid "9d82e85b-a02c-4bf0-b324-1eb0b5e81042" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Buitenlands Beleid" .
+
+ns16:a1fe00b2-9c52-40c1-8c37-3b68a78f4318 a skos:Concept ;
+    ns3:uuid "a1fe00b2-9c52-40c1-8c37-3b68a78f4318" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Sport" .
+
+ns16:abebd345-3650-400c-b317-9a8da2760f21 a skos:Concept ;
+    ns3:uuid "abebd345-3650-400c-b317-9a8da2760f21" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Overheid" .
+
+ns16:ae7c673f-fa44-494e-b8d5-5912734fd1f1 a skos:Concept ;
+    ns3:uuid "ae7c673f-fa44-494e-b8d5-5912734fd1f1" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Bestuurszaken" .
+
+ns16:b02eb8fb-4845-41a0-889e-cac83c5c07e7 a skos:Concept ;
+    ns3:uuid "b02eb8fb-4845-41a0-889e-cac83c5c07e7" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Onderwijs" .
+
+ns16:b17cba58-4154-474e-ad39-c4bf2d8fbb91 a skos:Concept ;
+    ns3:uuid "b17cba58-4154-474e-ad39-c4bf2d8fbb91" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Vorming" .
+
+ns16:bde8cad4-6f3b-4c9b-a871-b92666b22994 a skos:Concept ;
+    ns3:uuid "bde8cad4-6f3b-4c9b-a871-b92666b22994" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Staatshervorming en Communautaire Aangelegenheden" .
+
+ns16:c4cc3f3f-f14a-49b2-bd0d-40f5ec04ff55 a skos:Concept ;
+    ns3:uuid "c4cc3f3f-f14a-49b2-bd0d-40f5ec04ff55" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Bodemgrond" .
+
+ns16:c8a94efe-10a8-4f5f-a77a-2ca188dc7b51 a skos:Concept ;
+    ns3:uuid "c8a94efe-10a8-4f5f-a77a-2ca188dc7b51" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Innovatie" .
+
+ns16:c99b383e-edfb-420b-b6fb-b4eb742f2899 a skos:Concept ;
+    ns3:uuid "c99b383e-edfb-420b-b6fb-b4eb742f2899" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Brussel" .
+
+ns16:ca626cb0-7f48-4e2f-8c09-2c77d34bef47 a skos:Concept ;
+    ns3:uuid "ca626cb0-7f48-4e2f-8c09-2c77d34bef47" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Wetenschap" .
+
+ns16:da98cfcb-f30f-46ef-a7a6-c8aeb7bf4af7 a skos:Concept ;
+    ns3:uuid "da98cfcb-f30f-46ef-a7a6-c8aeb7bf4af7" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Haven" .
+
+ns16:ddf7a9b9-c7f2-4a67-9894-d46fd8ff47de a skos:Concept ;
+    ns3:uuid "ddf7a9b9-c7f2-4a67-9894-d46fd8ff47de" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Brussel en Vlaamse rand" .
+
+ns16:e40f54b0-17d2-4122-9886-73e8ff277069 a skos:Concept ;
+    ns3:uuid "e40f54b0-17d2-4122-9886-73e8ff277069" ;
+    owl:deprecated true ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Stedelijk Beleid" .
+
+ns16:ee9bda4a-f54a-41d5-be2f-9d45781623be a skos:Concept ;
+    ns3:uuid "ee9bda4a-f54a-41d5-be2f-9d45781623be" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Onderwijs en Vorming" .
+
+ns16:fa4e010f-84e9-4d65-9675-1604ad41de56 a skos:Concept ;
+    ns3:uuid "fa4e010f-84e9-4d65-9675-1604ad41de56" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Wonen" .
+
+ns16:faf802ff-bca7-4419-acc0-d84937e5bcd4 a skos:Concept ;
+    ns3:uuid "faf802ff-bca7-4419-acc0-d84937e5bcd4" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Economie" .
+
+ns16:fd6c39f5-cf5c-4a74-aff2-2eb5b4999a51 a skos:Concept ;
+    ns3:uuid "fd6c39f5-cf5c-4a74-aff2-2eb5b4999a51" ;
+    owl:deprecated false ;
+    skos:inScheme ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc ;
+    skos:prefLabel "Tewerkstelling" .
+
+ns8:2387564a-0897-4a62-9b9a-d1755eece7af a skos:Concept ;
+    ns3:uuid "2387564a-0897-4a62-9b9a-d1755eece7af" ;
+    skos:inScheme ns1:8030c0c4-aff1-4548-92d9-3299ebc43832 ;
+    skos:prefLabel "Elektronische procedure" .
+
+ns8:62a0a3c3-44ed-4f35-8b46-1d50616ad42c a skos:Concept ;
+    ns3:uuid "62a0a3c3-44ed-4f35-8b46-1d50616ad42c" ;
+    skos:inScheme ns1:8030c0c4-aff1-4548-92d9-3299ebc43832 ;
+    skos:prefLabel "Bijzondere ministerraad" .
+
+ns8:9b4701f8-a136-4009-94c6-d64fdc96b9a2 a skos:Concept ;
+    ns3:uuid "9b4701f8-a136-4009-94c6-d64fdc96b9a2" ;
+    skos:broader ns8:30d6a064-8cca-4485-8b37-7ab2357d931d ;
+    skos:inScheme ns1:8030c0c4-aff1-4548-92d9-3299ebc43832 ;
+    skos:prefLabel "Ministerraad - Plan Vlaamse Veerkracht" .
+
+ns8:ef51c9d5-8b45-4501-9dcd-3e00ccff524f a skos:Concept ;
+    ns3:uuid "ef51c9d5-8b45-4501-9dcd-3e00ccff524f" ;
+    skos:inScheme ns1:8030c0c4-aff1-4548-92d9-3299ebc43832 ;
+    skos:prefLabel "Ministerraad" .
+
+<http://themis.vlaanderen.be/id/rechtstreekse-verkiezing/5fed907ce6670526694a03e4> a ns17:RechtstreekseVerkiezing ;
+    ns17:datum "1981-11-08"^^xsd:date ;
+    ns17:steltSamen <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a03e3> ;
+    ns3:uuid "5fed907ce6670526694a03e4" .
+
+<http://themis.vlaanderen.be/id/rechtstreekse-verkiezing/5fed907ce6670526694a041e> a ns17:RechtstreekseVerkiezing ;
+    ns17:datum "1985-10-13"^^xsd:date ;
+    ns17:steltSamen <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a041d> ;
+    ns3:uuid "5fed907ce6670526694a041e" .
+
+<http://themis.vlaanderen.be/id/rechtstreekse-verkiezing/5fed907ce6670526694a0448> a ns17:RechtstreekseVerkiezing ;
+    ns17:datum "1987-12-13"^^xsd:date ;
+    ns17:steltSamen <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a0447> ;
+    ns3:uuid "5fed907ce6670526694a0448" .
+
+<http://themis.vlaanderen.be/id/rechtstreekse-verkiezing/5fed907ce6670526694a049a> a ns17:RechtstreekseVerkiezing ;
+    ns17:datum "1991-11-24"^^xsd:date ;
+    ns17:steltSamen <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a0499> ;
+    ns3:uuid "5fed907ce6670526694a049a" .
+
+<http://themis.vlaanderen.be/id/rechtstreekse-verkiezing/5fed907de6670526694a04ea> a ns17:RechtstreekseVerkiezing ;
+    ns17:datum "1995-05-21"^^xsd:date ;
+    ns17:steltSamen <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a04e9> ;
+    ns3:uuid "5fed907de6670526694a04ea" .
+
+<http://themis.vlaanderen.be/id/rechtstreekse-verkiezing/5fed907de6670526694a052e> a ns17:RechtstreekseVerkiezing ;
+    ns17:datum "1999-06-13"^^xsd:date ;
+    ns17:steltSamen <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a052d> ;
+    ns3:uuid "5fed907de6670526694a052e" .
+
+<http://themis.vlaanderen.be/id/rechtstreekse-verkiezing/5fed907de6670526694a05e6> a ns17:RechtstreekseVerkiezing ;
+    ns17:datum "2004-06-13"^^xsd:date ;
+    ns17:steltSamen <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a05e5> ;
+    ns3:uuid "5fed907de6670526694a05e6" .
+
+<http://themis.vlaanderen.be/id/rechtstreekse-verkiezing/5fed907ee6670526694a0653> a ns17:RechtstreekseVerkiezing ;
+    ns17:datum "2009-06-07"^^xsd:date ;
+    ns17:steltSamen <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0652> ;
+    ns3:uuid "5fed907ee6670526694a0653" .
+
+<http://themis.vlaanderen.be/id/rechtstreekse-verkiezing/5fed907ee6670526694a0685> a ns17:RechtstreekseVerkiezing ;
+    ns17:datum "2014-05-25"^^xsd:date ;
+    ns17:steltSamen <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0684> ;
+    ns3:uuid "5fed907ee6670526694a0685" .
+
+<http://themis.vlaanderen.be/id/rechtstreekse-verkiezing/5fed907ee6670526694a0701> a ns17:RechtstreekseVerkiezing ;
+    ns17:datum "2019-05-26"^^xsd:date ;
+    ns17:steltSamen <http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0700> ;
+    ns3:uuid "5fed907ee6670526694a0701" .
+
+ns1:eabe9bb8-d4e1-409e-9132-2d09e5a89bef a skos:ConceptScheme ;
+    ns3:uuid "eabe9bb8-d4e1-409e-9132-2d09e5a89bef" ;
+    skos:prefLabel "Activity types" .
+
+ns9:60d0dc2ab1838d01fca7db63 a skos:Concept ;
+    ns3:uuid "60d0dc2ab1838d01fca7db63" ;
+    skos:prefLabel "Gemeenschap" .
+
+ns9:ba6abed5-a5b7-482b-9c19-18d51a4a6e6f a skos:Concept ;
+    ns3:uuid "ba6abed5-a5b7-482b-9c19-18d51a4a6e6f" ;
+    skos:prefLabel "Gewest" .
+
+<http://themis.vlaanderen.be/id/concept/bestuursorgaan-classificatie/14b3f492-7106-46c7-9704-f547beff18ca> a skos:Concept ;
+    ns3:uuid "14b3f492-7106-46c7-9704-f547beff18ca" ;
+    skos:prefLabel "Gewestparlement" .
+
+<http://themis.vlaanderen.be/id/concept/bestuursorgaan-classificatie/18893b4f4c664ee182316cca1ecae156> a skos:Concept ;
+    ns3:uuid "18893b4f4c664ee182316cca1ecae156" ;
+    skos:prefLabel "Gemeenschapsregering" .
+
+<http://themis.vlaanderen.be/id/concept/bestuursorgaan-classificatie/9682bad6-9c85-4eeb-9ac1-bba21666469a> a skos:Concept ;
+    ns3:uuid "9682bad6-9c85-4eeb-9ac1-bba21666469a" ;
+    skos:prefLabel "Gewestregering" .
+
+ns8:30d6a064-8cca-4485-8b37-7ab2357d931d a skos:Concept ;
+    ns3:uuid "30d6a064-8cca-4485-8b37-7ab2357d931d" ;
+    skos:inScheme ns1:8030c0c4-aff1-4548-92d9-3299ebc43832 ;
+    skos:prefLabel "Annex" .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a03e8> a ns22:Generation ;
+    ns3:uuid "5fed907ce6670526694a03e8" ;
+    ns22:atTime "1981-12-22T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a041a> a ns22:Generation ;
+    ns3:uuid "5fed907ce6670526694a041a" ;
+    ns22:atTime "1981-12-22T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a0422> a ns22:Generation ;
+    ns3:uuid "5fed907ce6670526694a0422" ;
+    ns22:atTime "1985-12-11T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a0444> a ns22:Generation ;
+    ns3:uuid "5fed907ce6670526694a0444" ;
+    ns22:atTime "1985-12-11T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a044c> a ns22:Generation ;
+    ns3:uuid "5fed907ce6670526694a044c" ;
+    ns22:atTime "1988-02-03T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a0463> a ns22:Generation ;
+    ns3:uuid "5fed907ce6670526694a0463" ;
+    ns22:atTime "1988-10-23T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a0496> a ns22:Generation ;
+    ns3:uuid "5fed907ce6670526694a0496" ;
+    ns22:atTime "1988-02-03T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a049e> a ns22:Generation ;
+    ns3:uuid "5fed907ce6670526694a049e" ;
+    ns22:atTime "1992-01-22T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a04e6> a ns22:Generation ;
+    ns3:uuid "5fed907de6670526694a04e6" ;
+    ns22:atTime "1992-01-22T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a04ee> a ns22:Generation ;
+    ns3:uuid "5fed907de6670526694a04ee" ;
+    ns22:atTime "1995-06-20T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a052a> a ns22:Generation ;
+    ns3:uuid "5fed907de6670526694a052a" ;
+    ns22:atTime "1995-06-20T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a0532> a ns22:Generation ;
+    ns3:uuid "5fed907de6670526694a0532" ;
+    ns22:atTime "1999-07-13T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a05aa> a ns22:Generation ;
+    ns3:uuid "5fed907de6670526694a05aa" ;
+    ns22:atTime "2003-06-05T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a05b6> a ns22:Generation ;
+    ns3:uuid "5fed907de6670526694a05b6" ;
+    ns22:atTime "2003-06-10T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a05d6> a ns22:Generation ;
+    ns3:uuid "5fed907de6670526694a05d6" ;
+    ns22:atTime "2004-07-20T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a05e2> a ns22:Generation ;
+    ns3:uuid "5fed907de6670526694a05e2" ;
+    ns22:atTime "1999-07-13T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a05ea> a ns22:Generation ;
+    ns3:uuid "5fed907de6670526694a05ea" ;
+    ns22:atTime "2004-07-22T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a060b> a ns22:Generation ;
+    ns3:uuid "5fed907de6670526694a060b" ;
+    ns22:atTime "2007-06-28T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a064f> a ns22:Generation ;
+    ns3:uuid "5fed907ee6670526694a064f" ;
+    ns22:atTime "2004-07-22T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a0657> a ns22:Generation ;
+    ns3:uuid "5fed907ee6670526694a0657" ;
+    ns22:atTime "2009-07-13T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a0681> a ns22:Generation ;
+    ns3:uuid "5fed907ee6670526694a0681" ;
+    ns22:atTime "2009-07-13T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a0689> a ns22:Generation ;
+    ns3:uuid "5fed907ee6670526694a0689" ;
+    ns22:atTime "2014-07-25T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a06e2> a ns22:Generation ;
+    ns3:uuid "5fed907ee6670526694a06e2" ;
+    ns22:atTime "2019-07-02T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a06fd> a ns22:Generation ;
+    ns3:uuid "5fed907ee6670526694a06fd" ;
+    ns22:atTime "2014-07-25T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a0705> a ns22:Generation ;
+    ns3:uuid "5fed907ee6670526694a0705" ;
+    ns22:atTime "2019-10-02T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a071f> a ns22:Generation ;
+    ns3:uuid "5fed907ee6670526694a071f" ;
+    ns22:atTime "2019-10-02T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/creatie/60d0dc2ab1838d01fca7db6e> a ns22:Generation ;
+    ns3:uuid "60d0dc2ab1838d01fca7db6e" ;
+    ns22:atTime "1992-10-20T00:00:00+00:00"^^xsd:dateTime .
+
+ns26:09684a8d-ac57-4c8b-9727-42ed9a477e55 a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 6 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "09684a8d-ac57-4c8b-9727-42ed9a477e55" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:10a45f51-a511-4caa-8273-d1eb2c1ee27c a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 3 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "10a45f51-a511-4caa-8273-d1eb2c1ee27c" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0655> .
+
+ns26:1c829511-04b6-4ac4-99ad-06c6f1496535 a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "1c829511-04b6-4ac4-99ad-06c6f1496535" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:1e207740-3834-4e98-8431-5a2c08704516 a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 3 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "1e207740-3834-4e98-8431-5a2c08704516" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Bestuurszaken, Inburgering en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:32ca24e2-e216-43e0-b0af-e377137c0775 a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> ;
+    ns17:rangorde 7 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "32ca24e2-e216-43e0-b0af-e377137c0775" ;
+    ns21:title "Vlaams minister van Financiën, Begroting, Werk, Ruimtelijke Ordening en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:345dfd2a-3c09-42bc-a3d1-99ac8c72f515 a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 7 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "345dfd2a-3c09-42bc-a3d1-99ac8c72f515" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Innovatie, Media en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:3dc729d9-94b7-41f7-8c91-cc30951d6a56 a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06d2> ;
+    ns17:rangorde 8 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "3dc729d9-94b7-41f7-8c91-cc30951d6a56" ;
+    ns21:title "Vlaams minister van Mobiliteit en Openbare Werken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:3f4bfdbf-a8c4-4687-937d-7608b1e4270c a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0539> ;
+    ns17:rangorde 3 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "3f4bfdbf-a8c4-4687-937d-7608b1e4270c" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid, Gelijke Kansen en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:43b0ffea-8395-42c2-aad5-c7796c0cd33a a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 8 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "43b0ffea-8395-42c2-aad5-c7796c0cd33a" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Innovatie, Media en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:4ca19c47-a57e-4fbf-95dd-8d4e09d71ed8 a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "4ca19c47-a57e-4fbf-95dd-8d4e09d71ed8" ;
+    ns21:title "Vlaams minister van Financiën, Begroting, Buitenlands Beleid en Europese Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:532a4a5b-eabe-4f93-bc3a-7ef5f8f3c26e a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "532a4a5b-eabe-4f93-bc3a-7ef5f8f3c26e" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5678ff3c-ef96-4d19-b5a9-b383adcc69aa a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0714> ;
+    ns17:rangorde 5 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5678ff3c-ef96-4d19-b5a9-b383adcc69aa" ;
+    ns21:title "Vlaams minister van Justitie en Handhaving, Omgeving, Energie en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:57d1cd49-58bf-438b-9ca4-dd521fb02066 a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "57d1cd49-58bf-438b-9ca4-dd521fb02066" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5deb9bb2-204a-4fbe-93ba-edeb5fa7a57b a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0707> ;
+    ns17:rangorde 1 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5deb9bb2-204a-4fbe-93ba-edeb5fa7a57b" ;
+    ns21:title "Vlaams minister van Buitenlandse Zaken, Cultuur, Digitalisering en Facilitair Management" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:5fed907ce6670526694a03eb a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a03eb" ;
+    ns21:title "Gemeenschapsminister van Economie en Werkgelegenheid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a03ee a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a03ee" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e5> .
+
+ns26:5fed907ce6670526694a03f0 a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ef> ;
+    ns17:rangorde 2 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a03f0" ;
+    ns21:title "Gemeenschapsminister van Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a03f2 a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ef> ;
+    ns17:rangorde 2 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a03f2" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e6> .
+
+ns26:5fed907ce6670526694a03f4 a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03f3> ;
+    ns17:rangorde 3 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a03f4" ;
+    ns21:title "Gemeenschapsminister van Ondergeschikte Besturen en Gesubsidieerde Werken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a03f8 a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03f7> ;
+    ns17:rangorde 4 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a03f8" ;
+    ns21:title "Gemeenschapsminister van Gezin en Welzijnszorg" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a03fc a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03fb> ;
+    ns17:rangorde 5 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a03fc" ;
+    ns21:title "Gemeenschapsminister van Financiën" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a03ff a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03fe> ;
+    ns17:rangorde 6 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a03ff" ;
+    ns21:title "Gemeenschapsminister van Ruimtelijke Ordening, Landinrichting en Natuurbehoud" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a0404 a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0403> ;
+    ns17:rangorde 7 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0404" ;
+    ns21:title "Gemeenschapsminister van Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a0407 a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0406> ;
+    ns17:rangorde 8 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0407" ;
+    ns21:title "Gemeenschapsminister van Gezondheidsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a040a a ns17:Mandataris ;
+    ns17:einde "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0409> ;
+    ns17:rangorde 9 ;
+    ns17:start "1981-12-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a040a" ;
+    ns21:title "Gemeenschapsminister van Leefmilieu, Waterbeleid en Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a040e a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a040e" ;
+    ns21:title "Gemeenschapsminister van Economie en Werkgelegenheid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a040f a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a040f" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e5> .
+
+ns26:5fed907ce6670526694a0410 a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ef> ;
+    ns17:rangorde 2 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0410" ;
+    ns21:title "Gemeenschapsminister van Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a0411 a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ef> ;
+    ns17:rangorde 2 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0411" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e6> .
+
+ns26:5fed907ce6670526694a0412 a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03f3> ;
+    ns17:rangorde 3 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0412" ;
+    ns21:title "Gemeenschapsminister van Binnenlandse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a0414 a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03f7> ;
+    ns17:rangorde 4 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0414" ;
+    ns21:title "Gemeenschapsminister van Gezin en Welzijnszorg" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a0415 a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03fb> ;
+    ns17:rangorde 5 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0415" ;
+    ns21:title "Gemeenschapsminister van Financiën" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a0416 a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03fe> ;
+    ns17:rangorde 6 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0416" ;
+    ns21:title "Gemeenschapsminister van Ruimtelijke Ordening, Landinrichting en Natuurbehoud" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a0417 a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0403> ;
+    ns17:rangorde 7 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0417" ;
+    ns21:title "Gemeenschapsminister van Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a0418 a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0406> ;
+    ns17:rangorde 8 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0418" ;
+    ns21:title "Gemeenschapsminister van Gezondheidsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a0419 a ns17:Mandataris ;
+    ns17:einde "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0409> ;
+    ns17:rangorde 9 ;
+    ns17:start "1982-07-23T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0419" ;
+    ns21:title "Gemeenschapsminister van Leefmilieu, Waterbeleid en Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> .
+
+ns26:5fed907ce6670526694a0424 a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0424" ;
+    ns21:title "Gemeenschapsminister van Economie en Werkgelegenheid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a0425 a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0425" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a041f> .
+
+ns26:5fed907ce6670526694a0427 a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0426> ;
+    ns17:rangorde 2 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0427" ;
+    ns21:title "Gemeenschapsminister van Financiën en Begroting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a0429 a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0426> ;
+    ns17:rangorde 2 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0429" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0420> .
+
+ns26:5fed907ce6670526694a042a a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03f7> ;
+    ns17:rangorde 3 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a042a" ;
+    ns21:title "Gemeenschapsminister van Gezin en Welzijnszorg" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a042b a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03fe> ;
+    ns17:rangorde 4 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a042b" ;
+    ns21:title "Gemeenschapsminister van Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a042c a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0409> ;
+    ns17:rangorde 5 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a042c" ;
+    ns21:title "Gemeenschapsminister van Volksgezondheid en Leefmilieu" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a042f a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a042e> ;
+    ns17:rangorde 6 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a042f" ;
+    ns21:title "Gemeenschapsminister van Binnenlandse Aangelegenheden en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a0431 a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 7 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0431" ;
+    ns21:title "Gemeenschapsminister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a0434 a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0433> ;
+    ns17:rangorde 8 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0434" ;
+    ns21:title "Gemeenschapsminister van Externe Betrekkingen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a0437 a ns17:Mandataris ;
+    ns17:einde "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 9 ;
+    ns17:start "1985-12-11T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0437" ;
+    ns21:title "Gemeenschapsminister van Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a0438 a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0438" ;
+    ns21:title "Gemeenschapsminister van Economie en Werkgelegenheid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a0439 a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0439" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a041f> .
+
+ns26:5fed907ce6670526694a043a a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0426> ;
+    ns17:rangorde 2 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a043a" ;
+    ns21:title "Gemeenschapsminister van Financiën en Begroting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a043b a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0426> ;
+    ns17:rangorde 2 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a043b" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0420> .
+
+ns26:5fed907ce6670526694a043c a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03f7> ;
+    ns17:rangorde 3 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a043c" ;
+    ns21:title "Gemeenschapsminister van Gezin en Welzijnszorg" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a043d a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0409> ;
+    ns17:rangorde 4 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a043d" ;
+    ns21:title "Gemeenschapsminister van Volksgezondheid en Leefmilieu" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a043e a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a042e> ;
+    ns17:rangorde 5 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a043e" ;
+    ns21:title "Gemeenschapsminister van Binnenlandse Aangelegenheden en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a043f a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 6 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a043f" ;
+    ns21:title "Gemeenschapsminister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a0440 a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0433> ;
+    ns17:rangorde 7 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0440" ;
+    ns21:title "Gemeenschapsminister van Externe Betrekkingen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a0441 a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 8 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0441" ;
+    ns21:title "Gemeenschapsminister van Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a0443 a ns17:Mandataris ;
+    ns17:einde "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0442> ;
+    ns17:rangorde 9 ;
+    ns17:start "1987-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0443" ;
+    ns21:title "Gemeenschapsminister van Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> .
+
+ns26:5fed907ce6670526694a044e a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a044e" ;
+    ns21:title "Gemeenschapsminister van Economie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a044f a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a044f" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0449> .
+
+ns26:5fed907ce6670526694a0450 a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0426> ;
+    ns17:rangorde 2 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0450" ;
+    ns21:title "Gemeenschapsminister van Financiën en Begroting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0451 a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0426> ;
+    ns17:rangorde 2 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0451" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044a> .
+
+ns26:5fed907ce6670526694a0452 a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0409> ;
+    ns17:rangorde 3 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0452" ;
+    ns21:title "Gemeenschapsminister van Welzijn, Gezin en Volksgezondheid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0454 a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 4 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0454" ;
+    ns21:title "Gemeenschapsminister van Tewerkstelling, Vorming en Openbaar Ambt" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0458 a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 5 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0458" ;
+    ns21:title "Gemeenschapsminister van Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a045a a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0442> ;
+    ns17:rangorde 6 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a045a" ;
+    ns21:title "Gemeenschapsminister van Leefmilieu, Landinrichting en KMO-beleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a045d a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> ;
+    ns17:rangorde 7 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a045d" ;
+    ns21:title "Gemeenschapsminister van Onderwijs en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0460 a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045f> ;
+    ns17:rangorde 8 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0460" ;
+    ns21:title "Gemeenschapsminister van Binnenlandse Aangelegenheden en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0462 a ns17:Mandataris ;
+    ns17:einde "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0461> ;
+    ns17:rangorde 9 ;
+    ns17:start "1988-02-03T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0462" ;
+    ns21:title "Gemeenschapsminister van Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0465 a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0465" ;
+    ns21:title "Gemeenschapsminister van Financiën en Begroting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0466 a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0466" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0449> .
+
+ns26:5fed907ce6670526694a0468 a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0468" ;
+    ns21:title "Gemeenschapsminister van Economie, Middenstand en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a046b a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a046b" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044a> .
+
+ns26:5fed907ce6670526694a046c a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0426> ;
+    ns17:rangorde 3 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a046c" ;
+    ns21:title "Gemeenschapsminister van Ruimtelijke Ordening en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a046d a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0409> ;
+    ns17:rangorde 4 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a046d" ;
+    ns21:title "Gemeenschapsminister van Welzijn en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a046e a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0406> ;
+    ns17:rangorde 5 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a046e" ;
+    ns21:title "Gemeenschapsminister van Tewerkstelling" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a046f a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 6 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a046f" ;
+    ns21:title "Gemeenschapsminister van Leefmilieu, Natuurbehoud en Landinrichting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0470 a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 7 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0470" ;
+    ns21:title "Gemeenschapsminister van Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0471 a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> ;
+    ns17:rangorde 8 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0471" ;
+    ns21:title "Gemeenschapsminister van Volksgezondheid en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0473 a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0472> ;
+    ns17:rangorde 9 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0473" ;
+    ns21:title "Gemeenschapsminister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0475 a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 10 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0475" ;
+    ns21:title "Gemeenschapsminister van Binnenlandse Aangelegenheden en Openbaar Ambt" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0477 a ns17:Mandataris ;
+    ns17:einde "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> ;
+    ns17:rangorde 11 ;
+    ns17:start "1988-10-23T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0477" ;
+    ns21:title "Gemeenschapsminister van Openbare Werken en Verkeer" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a047a a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a047a" ;
+    ns21:title "Gemeenschapsminister van Financiën en Begroting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a047b a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a047b" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0449> .
+
+ns26:5fed907ce6670526694a047c a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a047c" ;
+    ns21:title "Gemeenschapsminister van Economie, Middenstand en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a047d a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a047d" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044a> .
+
+ns26:5fed907ce6670526694a047e a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0426> ;
+    ns17:rangorde 3 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a047e" ;
+    ns21:title "Gemeenschapsminister van Ruimtelijke Ordening en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a047f a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0409> ;
+    ns17:rangorde 4 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a047f" ;
+    ns21:title "Gemeenschapsminister van Welzijn en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0480 a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0406> ;
+    ns17:rangorde 5 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0480" ;
+    ns21:title "Gemeenschapsminister van Tewerkstelling" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0481 a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 6 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0481" ;
+    ns21:title "Gemeenschapsminister van Leefmilieu, Natuurbehoud en Landinrichting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0482 a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 7 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0482" ;
+    ns21:title "Gemeenschapsminister van Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0483 a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> ;
+    ns17:rangorde 8 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0483" ;
+    ns21:title "Gemeenschapsminister van Volksgezondheid en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0484 a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0472> ;
+    ns17:rangorde 9 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0484" ;
+    ns21:title "Gemeenschapsminister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0485 a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 10 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0485" ;
+    ns21:title "Gemeenschapsminister van Binnenlandse Aangelegenheden en Openbaar Ambt" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0486 a ns17:Mandataris ;
+    ns17:einde "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> ;
+    ns17:rangorde 11 ;
+    ns17:start "1989-02-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0486" ;
+    ns21:title "Gemeenschapsminister van Openbare Werken en Verkeer" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0487 a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0487" ;
+    ns21:title "Gemeenschapsminister van Financiën en Begroting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0488 a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> ;
+    ns17:rangorde 1 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0488" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0449> .
+
+ns26:5fed907ce6670526694a0489 a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0489" ;
+    ns21:title "Gemeenschapsminister van Economie, Middenstand en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a048a a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a048a" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044a> .
+
+ns26:5fed907ce6670526694a048b a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0409> ;
+    ns17:rangorde 3 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a048b" ;
+    ns21:title "Gemeenschapsminister van Welzijn en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a048c a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0406> ;
+    ns17:rangorde 4 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a048c" ;
+    ns21:title "Gemeenschapsminister van Tewerkstelling" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a048d a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 5 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a048d" ;
+    ns21:title "Gemeenschapsminister van Leefmilieu, Natuurbehoud en Plattelandsvernieuwing" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a048f a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 6 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a048f" ;
+    ns21:title "Gemeenschapsminister van Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0490 a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> ;
+    ns17:rangorde 7 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0490" ;
+    ns21:title "Gemeenschapsminister van Volksgezondheid en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0491 a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0472> ;
+    ns17:rangorde 8 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0491" ;
+    ns21:title "Gemeenschapsminister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0492 a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 9 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0492" ;
+    ns21:title "Gemeenschapsminister van Binnenlandse Aangelegenheden en Openbaar Ambt" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a0493 a ns17:Mandataris ;
+    ns17:einde "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> ;
+    ns17:rangorde 10 ;
+    ns17:start "1992-01-08T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a0493" ;
+    ns21:title "Gemeenschapsminister van Minister van Openbare Werken en Communicatie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> .
+
+ns26:5fed907ce6670526694a04a1 a ns17:Mandataris ;
+    ns17:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04a1" ;
+    ns21:title "Gemeenschapsminister van Economie, KMO, Energie en Externe Betrekkingen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04a2 a ns17:Mandataris ;
+    ns17:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04a2" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db68> .
+
+ns26:5fed907ce6670526694a04a3 a ns17:Mandataris ;
+    ns17:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04a3" ;
+    ns21:title "Gemeenschapsminister van Leefmilieu, Huisvesting en Wetenschapsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04a5 a ns17:Mandataris ;
+    ns17:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04a5" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db69> .
+
+ns26:5fed907ce6670526694a04a6 a ns17:Mandataris ;
+    ns17:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 3 ;
+    ns17:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04a6" ;
+    ns21:title "Gemeenschapsminister van Openbare Werken, Vervoer en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04a8 a ns17:Mandataris ;
+    ns17:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> ;
+    ns17:rangorde 4 ;
+    ns17:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04a8" ;
+    ns21:title "Gemeenschapsminister van Cultuur en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04a9 a ns17:Mandataris ;
+    ns17:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 5 ;
+    ns17:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04a9" ;
+    ns21:title "Gemeenschapsminister van Onderwijs en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04ac a ns17:Mandataris ;
+    ns17:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ab> ;
+    ns17:rangorde 6 ;
+    ns17:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04ac" ;
+    ns21:title "Gemeenschapsminister van Tewerkstelling en Volksgezondheid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04ae a ns17:Mandataris ;
+    ns17:einde "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> ;
+    ns17:rangorde 7 ;
+    ns17:start "1992-01-22T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04ae" ;
+    ns21:title "Gemeenschapsminister van Financiën en Begroting, Binnenlandse Aangelegenheden, Welzijn en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04af a ns17:Mandataris ;
+    ns17:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04af" ;
+    ns21:title "Gemeenschapsminister van Economie, KMO, Wetenschapsbeleid, Energie en Externe Betrekkingen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04b1 a ns17:Mandataris ;
+    ns17:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04b1" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db68> .
+
+ns26:5fed907ce6670526694a04b2 a ns17:Mandataris ;
+    ns17:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04b2" ;
+    ns21:title "Gemeenschapsminister van Leefmilieu en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04b3 a ns17:Mandataris ;
+    ns17:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04b3" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db69> .
+
+ns26:5fed907ce6670526694a04b4 a ns17:Mandataris ;
+    ns17:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 3 ;
+    ns17:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04b4" ;
+    ns21:title "Gemeenschapsminister van Openbare Werken, Ruimtelijke Ordening en Binnenlandse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04b5 a ns17:Mandataris ;
+    ns17:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> ;
+    ns17:rangorde 4 ;
+    ns17:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04b5" ;
+    ns21:title "Gemeenschapsminister van Cultuur en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04b6 a ns17:Mandataris ;
+    ns17:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 5 ;
+    ns17:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04b6" ;
+    ns21:title "Gemeenschapsminister van Onderwijs en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04b7 a ns17:Mandataris ;
+    ns17:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> ;
+    ns17:rangorde 6 ;
+    ns17:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04b7" ;
+    ns21:title "Gemeenschapsminister van Verkeer, Buitenlandse Handel en Staatshervorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04ba a ns17:Mandataris ;
+    ns17:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ab> ;
+    ns17:rangorde 7 ;
+    ns17:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04ba" ;
+    ns21:title "Gemeenschapsminister van Tewerkstelling en Sociale Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04bc a ns17:Mandataris ;
+    ns17:einde "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> ;
+    ns17:rangorde 8 ;
+    ns17:start "1992-01-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04bc" ;
+    ns21:title "Gemeenschapsminister van Financiën en Begroting, Gezondheidsinstellingen, Welzijn en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> .
+
+ns26:5fed907ce6670526694a04be a ns17:Mandataris ;
+    ns17:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04be" ;
+    ns21:title "Vlaams minister van Economie, KMO, Wetenschapsbeleid, Energie en Externe Betrekkingen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04bf a ns17:Mandataris ;
+    ns17:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04bf" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049b> .
+
+ns26:5fed907ce6670526694a04c0 a ns17:Mandataris ;
+    ns17:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04c0" ;
+    ns21:title "Vlaams minister van Leefmilieu en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04c1 a ns17:Mandataris ;
+    ns17:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04c1" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049c> .
+
+ns26:5fed907ce6670526694a04c2 a ns17:Mandataris ;
+    ns17:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 3 ;
+    ns17:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04c2" ;
+    ns21:title "Vlaams minister van Openbare Werken, Ruimtelijke Ordening en Binnenlandse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04c3 a ns17:Mandataris ;
+    ns17:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> ;
+    ns17:rangorde 4 ;
+    ns17:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04c3" ;
+    ns21:title "Vlaams minister van Cultuur en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04c4 a ns17:Mandataris ;
+    ns17:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 5 ;
+    ns17:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04c4" ;
+    ns21:title "Vlaams minister van Onderwijs en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04c5 a ns17:Mandataris ;
+    ns17:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> ;
+    ns17:rangorde 6 ;
+    ns17:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04c5" ;
+    ns21:title "Vlaams minister van Verkeer, Buitenlandse Handel en Staatshervorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04c6 a ns17:Mandataris ;
+    ns17:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ab> ;
+    ns17:rangorde 7 ;
+    ns17:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04c6" ;
+    ns21:title "Vlaams minister van Tewerkstelling en Sociale Aangelegendheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04c8 a ns17:Mandataris ;
+    ns17:einde "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> ;
+    ns17:rangorde 8 ;
+    ns17:start "1992-10-20T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04c8" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Gezondheidsinstellingen, Welzijn en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04c9 a ns17:Mandataris ;
+    ns17:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04c9" ;
+    ns21:title "Vlaams minister van Economie, KMO, Wetenschapsbeleid, Energie en Externe Betrekkingen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04ca a ns17:Mandataris ;
+    ns17:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04ca" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049b> .
+
+ns26:5fed907ce6670526694a04cb a ns17:Mandataris ;
+    ns17:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04cb" ;
+    ns21:title "Vlaams minister van Leefmilieu en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04cc a ns17:Mandataris ;
+    ns17:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04cc" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049c> .
+
+ns26:5fed907ce6670526694a04cd a ns17:Mandataris ;
+    ns17:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 3 ;
+    ns17:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04cd" ;
+    ns21:title "Vlaams minister van Openbare Werken, Ruimtelijke Ordening en Binnenlandse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04ce a ns17:Mandataris ;
+    ns17:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> ;
+    ns17:rangorde 4 ;
+    ns17:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04ce" ;
+    ns21:title "Vlaams minister van Cultuur en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04cf a ns17:Mandataris ;
+    ns17:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 5 ;
+    ns17:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04cf" ;
+    ns21:title "Vlaams minister van Onderwijs en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04d0 a ns17:Mandataris ;
+    ns17:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> ;
+    ns17:rangorde 6 ;
+    ns17:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04d0" ;
+    ns21:title "Vlaams minister van Verkeer, Buitenlandse Handel en Staatshervorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04d1 a ns17:Mandataris ;
+    ns17:einde "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> ;
+    ns17:rangorde 7 ;
+    ns17:start "1995-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04d1" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Gezondheidsinstellingen, Welzijn en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907ce6670526694a04d2 a ns17:Mandataris ;
+    ns17:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ce6670526694a04d2" ;
+    ns21:title "Vlaams minister van Economie, KMO, Wetenschapsbeleid, Energie en Externe Betrekkingen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04d3 a ns17:Mandataris ;
+    ns17:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04d3" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049b> .
+
+ns26:5fed907de6670526694a04d4 a ns17:Mandataris ;
+    ns17:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04d4" ;
+    ns21:title "Vlaams minister van Leefmilieu en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04d5 a ns17:Mandataris ;
+    ns17:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> ;
+    ns17:rangorde 2 ;
+    ns17:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04d5" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049c> .
+
+ns26:5fed907de6670526694a04d6 a ns17:Mandataris ;
+    ns17:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 3 ;
+    ns17:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04d6" ;
+    ns21:title "Vlaams minister van Openbare Werken, Ruimtelijke Ordening en Binnenlandse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04d7 a ns17:Mandataris ;
+    ns17:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> ;
+    ns17:rangorde 4 ;
+    ns17:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04d7" ;
+    ns21:title "Vlaams minister van Cultuur en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04d8 a ns17:Mandataris ;
+    ns17:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 5 ;
+    ns17:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04d8" ;
+    ns21:title "Vlaams minister van Onderwijs en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04d9 a ns17:Mandataris ;
+    ns17:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> ;
+    ns17:rangorde 6 ;
+    ns17:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04d9" ;
+    ns21:title "Vlaams minister van Verkeer, Buitenlandse Handel en Staatshervorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04da a ns17:Mandataris ;
+    ns17:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> ;
+    ns17:rangorde 7 ;
+    ns17:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04da" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Gezondheidsinstellingen, Welzijn en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04dc a ns17:Mandataris ;
+    ns17:einde "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04db> ;
+    ns17:rangorde 8 ;
+    ns17:start "1995-01-12T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04dc" ;
+    ns21:title "Vlaams minister van Tewerkstelling en Sociale Aangelegendheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04dd a ns17:Mandataris ;
+    ns17:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04dd" ;
+    ns21:title "Vlaams minister van Economie, KMO, Wetenschapsbeleid, Energie en Externe Betrekkingen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04de a ns17:Mandataris ;
+    ns17:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04de" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049b> .
+
+ns26:5fed907de6670526694a04df a ns17:Mandataris ;
+    ns17:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 2 ;
+    ns17:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04df" ;
+    ns21:title "Vlaams minister van Openbare Werken, Ruimtelijke Ordening en Binnenlandse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04e0 a ns17:Mandataris ;
+    ns17:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> ;
+    ns17:rangorde 3 ;
+    ns17:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04e0" ;
+    ns21:title "Vlaams minister van Cultuur en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04e1 a ns17:Mandataris ;
+    ns17:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 4 ;
+    ns17:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04e1" ;
+    ns21:title "Vlaams minister van Onderwijs en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04e2 a ns17:Mandataris ;
+    ns17:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> ;
+    ns17:rangorde 5 ;
+    ns17:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04e2" ;
+    ns21:title "Vlaams minister van Vervoer, Buitenlandse Handel en Staatshervorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04e3 a ns17:Mandataris ;
+    ns17:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> ;
+    ns17:rangorde 6 ;
+    ns17:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04e3" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Gezondheidsinstellingen, Welzijn en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04e4 a ns17:Mandataris ;
+    ns17:einde "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04db> ;
+    ns17:rangorde 7 ;
+    ns17:start "1995-06-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04e4" ;
+    ns21:title "Vlaamse minister van Tewerkstelling, Sociale Aangelegenheden, Leefmilieu en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> .
+
+ns26:5fed907de6670526694a04f0 a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04f0" ;
+    ns21:title "Vlaams minister van Buitenlands Beleid, Europese Aangelegenheden, Wetenschap en Technologie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a04f5 a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04f5" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04eb> .
+
+ns26:5fed907de6670526694a04f6 a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 2 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04f6" ;
+    ns21:title "Vlaams minister van Onderwijs en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a04f7 a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 2 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04f7" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ec> .
+
+ns26:5fed907de6670526694a04f8 a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 3 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04f8" ;
+    ns21:title "Vlaams minister van Leefmilieu en Tewerkstelling" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a04f9 a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> ;
+    ns17:rangorde 4 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04f9" ;
+    ns21:title "Vlaams minister van Financiën, Begroting en Gezondheidsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a04fa a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04db> ;
+    ns17:rangorde 5 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04fa" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Stedelijk Beleid en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a04fd a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04fc> ;
+    ns17:rangorde 6 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04fd" ;
+    ns21:title "Vlaams minister van Openbare Werken, Vervoer en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a04ff a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04fe> ;
+    ns17:rangorde 7 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a04ff" ;
+    ns21:title "Vlaams minister van Cultuur, Gezin en Welzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0501 a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0500> ;
+    ns17:rangorde 8 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0501" ;
+    ns21:title "Vlaams minister van Economie, KMO, Landbouw en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0505 a ns17:Mandataris ;
+    ns17:einde "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0504> ;
+    ns17:rangorde 9 ;
+    ns17:start "1995-06-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0505" ;
+    ns21:title "Vlaams minister van Brusselse Aangelegenheden en Gelijkekansenbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0507 a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0507" ;
+    ns21:title "Vlaams minister van Buitenlands Beleid, Europese Aangelegenheden, Wetenschap en Technologie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0508 a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0508" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04eb> .
+
+ns26:5fed907de6670526694a0509 a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 2 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0509" ;
+    ns21:title "Vlaams minister van Onderwijs en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a050a a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 2 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a050a" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ec> .
+
+ns26:5fed907de6670526694a050b a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 3 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a050b" ;
+    ns21:title "Vlaams minister van Leefmilieu en Tewerkstelling" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a050c a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> ;
+    ns17:rangorde 4 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a050c" ;
+    ns21:title "Vlaams minister van Financiën, Begroting en Gezondheidsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a050d a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04db> ;
+    ns17:rangorde 5 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a050d" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Stedelijk Beleid en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a050e a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04fc> ;
+    ns17:rangorde 6 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a050e" ;
+    ns21:title "Vlaams minister van Openbare Werken, Vervoer en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a050f a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04fe> ;
+    ns17:rangorde 7 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a050f" ;
+    ns21:title "Vlaams minister van Cultuur, Gezin en Welzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0510 a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0500> ;
+    ns17:rangorde 8 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0510" ;
+    ns21:title "Vlaams minister van Economie, KMO, Landbouw en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0512 a ns17:Mandataris ;
+    ns17:einde "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0511> ;
+    ns17:rangorde 9 ;
+    ns17:start "1997-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0512" ;
+    ns21:title "Vlaams minister van Brusselse Aangelegenheden en Gelijkekansenbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0513 a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0513" ;
+    ns21:title "Vlaams minister van Buitenlands Beleid, Europese Aangelegenheden, Wetenschap en Technologie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0514 a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0514" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04eb> .
+
+ns26:5fed907de6670526694a0515 a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 2 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0515" ;
+    ns21:title "Vlaams minister van Onderwijs en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0516 a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> ;
+    ns17:rangorde 2 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0516" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ec> .
+
+ns26:5fed907de6670526694a0517 a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 3 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0517" ;
+    ns21:title "Vlaams minister van Leefmilieu en Tewerkstelling" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0518 a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> ;
+    ns17:rangorde 4 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0518" ;
+    ns21:title "Vlaams minister van Financiën, Begroting en Gezondheidsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0519 a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04db> ;
+    ns17:rangorde 5 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0519" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Stedelijk Beleid en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a051a a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04fc> ;
+    ns17:rangorde 6 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a051a" ;
+    ns21:title "Vlaams minister van Openbare Werken, Vervoer en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a051b a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04fe> ;
+    ns17:rangorde 7 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a051b" ;
+    ns21:title "Vlaams minister van Cultuur, Gezin en Welzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a051c a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0500> ;
+    ns17:rangorde 8 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a051c" ;
+    ns21:title "Vlaams minister van Economie, KMO, Landbouw en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a051d a ns17:Mandataris ;
+    ns17:einde "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0511> ;
+    ns17:rangorde 9 ;
+    ns17:start "1998-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a051d" ;
+    ns21:title "Vlaams minister van Brusselse Aangelegenheden en Gelijkekansenbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a051e a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a051e" ;
+    ns21:title "Vlaams minister van Buitenlands Beleid, Europese Aangelegenheden, Wetenschap en Technologie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a051f a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> ;
+    ns17:rangorde 1 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a051f" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04eb> .
+
+ns26:5fed907de6670526694a0521 a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0521" ;
+    ns21:title "Vlaams minister van Openbare Werken, Vervoer en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0522 a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0522" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ec> .
+
+ns26:5fed907de6670526694a0523 a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> ;
+    ns17:rangorde 3 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0523" ;
+    ns21:title "Vlaams minister van Leefmilieu en Tewerkstelling" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0524 a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> ;
+    ns17:rangorde 4 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0524" ;
+    ns21:title "Vlaams minister van Financiën, Begroting en Gezondheidsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0525 a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04db> ;
+    ns17:rangorde 5 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0525" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Stedelijk Beleid en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0526 a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04fc> ;
+    ns17:rangorde 6 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0526" ;
+    ns21:title "Vlaams minister van Onderwijs en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0527 a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04fe> ;
+    ns17:rangorde 7 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0527" ;
+    ns21:title "Vlaams minister van Cultuur, Gezin en Welzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0528 a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0500> ;
+    ns17:rangorde 8 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0528" ;
+    ns21:title "Vlaams minister van Economie, KMO, Landbouw en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0529 a ns17:Mandataris ;
+    ns17:einde "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0511> ;
+    ns17:rangorde 9 ;
+    ns17:start "1998-09-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0529" ;
+    ns21:title "Vlaams minister van Brusselse Aangelegenheden en Gelijkekansenbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> .
+
+ns26:5fed907de6670526694a0534 a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0534" ;
+    ns21:title "Vlaams minister van Financiën, Begroting, Buitenlands Beleid en Europese Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0535 a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0535" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a0536 a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0536" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0538 a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0538" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a053a a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0539> ;
+    ns17:rangorde 3 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a053a" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a053e a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 4 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a053e" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Stedelijk Beleid, Huisvesting en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0541 a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 5 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0541" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0543 a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 6 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0543" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0546 a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0545> ;
+    ns17:rangorde 7 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0546" ;
+    ns21:title "Vlaams minister van Leefmilieu en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0547 a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> ;
+    ns17:rangorde 8 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0547" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Ambtenarenzaken en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a054a a ns17:Mandataris ;
+    ns17:einde "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 9 ;
+    ns17:start "1999-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a054a" ;
+    ns21:title "Vlaams minister van Economie, Ruimtelijke Ordening en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a054b a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a054b" ;
+    ns21:title "Vlaams minister van Financiën, Begroting, Buitenlands Beleid en Europese Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a054c a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a054c" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a054d a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a054d" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a054e a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a054e" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a054f a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0539> ;
+    ns17:rangorde 3 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a054f" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0550 a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 4 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0550" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Brusselse Aangelegenheden en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0552 a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 5 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0552" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0553 a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 6 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0553" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0554 a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0545> ;
+    ns17:rangorde 7 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0554" ;
+    ns21:title "Vlaams minister van Leefmilieu en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0555 a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> ;
+    ns17:rangorde 8 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0555" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Ambtenarenzaken en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0556 a ns17:Mandataris ;
+    ns17:einde "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 9 ;
+    ns17:start "2000-04-14T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0556" ;
+    ns21:title "Vlaams minister van Economie, Ruimtelijke Ordening en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0557 a ns17:Mandataris ;
+    ns17:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0557" ;
+    ns21:title "Vlaams minister van Financiën, Begroting, Buitenlands Beleid en Europese Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0558 a ns17:Mandataris ;
+    ns17:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0558" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a0559 a ns17:Mandataris ;
+    ns17:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0559" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a055a a ns17:Mandataris ;
+    ns17:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a055a" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a055b a ns17:Mandataris ;
+    ns17:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0539> ;
+    ns17:rangorde 3 ;
+    ns17:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a055b" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a055c a ns17:Mandataris ;
+    ns17:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 4 ;
+    ns17:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a055c" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Brusselse Aangelegenheden en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a055d a ns17:Mandataris ;
+    ns17:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 5 ;
+    ns17:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a055d" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a055e a ns17:Mandataris ;
+    ns17:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 6 ;
+    ns17:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a055e" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a055f a ns17:Mandataris ;
+    ns17:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0545> ;
+    ns17:rangorde 7 ;
+    ns17:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a055f" ;
+    ns21:title "Vlaams minister van Leefmilieu en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0560 a ns17:Mandataris ;
+    ns17:einde "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 8 ;
+    ns17:start "2001-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0560" ;
+    ns21:title "Vlaams minister van Economie, Ruimtelijke Ordening en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0561 a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0561" ;
+    ns21:title "Vlaams minister van Financiën, Begroting, Buitenlands Beleid en Europese Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0562 a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0562" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a0563 a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0563" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0564 a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0564" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a0565 a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0539> ;
+    ns17:rangorde 3 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0565" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0566 a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 4 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0566" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Brusselse Aangelegenheden en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0567 a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 5 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0567" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0568 a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 6 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0568" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0569 a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0545> ;
+    ns17:rangorde 7 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0569" ;
+    ns21:title "Vlaams minister van Leefmilieu en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a056a a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 8 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a056a" ;
+    ns21:title "Vlaams minister van Economie, Ruimtelijke Ordening en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a056c a ns17:Mandataris ;
+    ns17:einde "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 9 ;
+    ns17:start "2001-05-11T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a056c" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Huisvesting en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a056f a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a056f" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a0570 a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0570" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0571 a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0571" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a0572 a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0539> ;
+    ns17:rangorde 3 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0572" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0573 a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 4 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0573" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Sport, Brusselse Aangelegenheden en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0574 a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 5 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0574" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0575 a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 6 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0575" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0576 a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0545> ;
+    ns17:rangorde 7 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0576" ;
+    ns21:title "Vlaams minister van Leefmilieu en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0577 a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 8 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0577" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Innovatie, Media en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0578 a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 9 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0578" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Ambtenarenzaken en Buitenlands Beleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a057a a ns17:Mandataris ;
+    ns17:einde "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0579> ;
+    ns17:rangorde 10 ;
+    ns17:start "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a057a" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a057c a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a057c" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a057d a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a057d" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a057e a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a057e" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a057f a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0539> ;
+    ns17:rangorde 3 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a057f" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid, Gelijke Kansen en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0580 a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 4 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0580" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0581 a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 5 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0581" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0582 a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0545> ;
+    ns17:rangorde 6 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0582" ;
+    ns21:title "Vlaams minister van Leefmilieu en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0583 a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 7 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0583" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Innovatie, Media en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0585 a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 8 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0585" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Cultuur, Jeugd en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0586 a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0579> ;
+    ns17:rangorde 9 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0586" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid, Buitenlandse Handel en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0588 a ns17:Mandataris ;
+    ns17:einde "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0587> ;
+    ns17:rangorde 10 ;
+    ns17:start "2002-07-03T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0588" ;
+    ns21:title "Vlaams minister van Sport en Brusselse Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a058a a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a058a" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a058b a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 2 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a058b" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a058c a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 2 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a058c" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a058d a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0539> ;
+    ns17:rangorde 3 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a058d" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a058e a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 4 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a058e" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a058f a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0545> ;
+    ns17:rangorde 5 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a058f" ;
+    ns21:title "Vlaams minister van Leefmilieu en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0590 a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 6 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0590" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Innovatie, Media en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0591 a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 7 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0591" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Cultuur, Jeugd en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0592 a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0579> ;
+    ns17:rangorde 8 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0592" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid, Buitenlandse Handel en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0595 a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0587> ;
+    ns17:rangorde 9 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0595" ;
+    ns21:title "Vlaams minister van Sport en Hoofdstedelijke Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a0598 a ns17:Mandataris ;
+    ns17:einde "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0597> ;
+    ns17:rangorde 10 ;
+    ns17:start "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0598" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a059a a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a059a" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a059b a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 2 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a059b" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a059c a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 2 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a059c" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a059d a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 3 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a059d" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a059e a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 4 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a059e" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Ruimtelijke Ordening, Wetenschappen en Technologische Innovatie " ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05a1 a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 5 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05a1" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Cultuur, Jeugd en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05a2 a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0579> ;
+    ns17:rangorde 6 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05a2" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid, Buitenlandse Handel en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05a3 a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0587> ;
+    ns17:rangorde 7 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05a3" ;
+    ns21:title "Vlaams minister van Sport en Hoofdstedelijke Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05a5 a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0597> ;
+    ns17:rangorde 8 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05a5" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05a7 a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05a6> ;
+    ns17:rangorde 9 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05a7" ;
+    ns21:title "Vlaams minister van Leefmilieu, Landbouw en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05a9 a ns17:Mandataris ;
+    ns17:einde "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05a8> ;
+    ns17:rangorde 10 ;
+    ns17:start "2003-05-26T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05a9" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05ac a ns17:Mandataris ;
+    ns17:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 1 ;
+    ns17:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05ac" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05ad a ns17:Mandataris ;
+    ns17:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 1 ;
+    ns17:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05ad" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a05ae a ns17:Mandataris ;
+    ns17:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 2 ;
+    ns17:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05ae" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05af a ns17:Mandataris ;
+    ns17:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 3 ;
+    ns17:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05af" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Ruimtelijke Ordening, Wetenschappen en Technologische Innovatie " ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05b0 a ns17:Mandataris ;
+    ns17:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 4 ;
+    ns17:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05b0" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Cultuur, Jeugd en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05b1 a ns17:Mandataris ;
+    ns17:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0579> ;
+    ns17:rangorde 5 ;
+    ns17:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05b1" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid, Buitenlandse Handel en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05b2 a ns17:Mandataris ;
+    ns17:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0587> ;
+    ns17:rangorde 6 ;
+    ns17:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05b2" ;
+    ns21:title "Vlaams minister van Sport en Hoofdstedelijke Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05b3 a ns17:Mandataris ;
+    ns17:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0597> ;
+    ns17:rangorde 7 ;
+    ns17:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05b3" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05b4 a ns17:Mandataris ;
+    ns17:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05a6> ;
+    ns17:rangorde 8 ;
+    ns17:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05b4" ;
+    ns21:title "Vlaams minister van Leefmilieu, Landbouw en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05b5 a ns17:Mandataris ;
+    ns17:einde "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05a8> ;
+    ns17:rangorde 9 ;
+    ns17:start "2003-06-05T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05b5" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05ba a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 1 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05ba" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a05bb a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 2 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05bb" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05bc a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 2 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05bc" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a05bd a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 3 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05bd" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05be a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 4 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05be" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Ruimtelijke Ordening, Wetenschappen en Technologische Innovatie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05bf a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 5 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05bf" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Cultuur, Jeugd en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05c0 a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0597> ;
+    ns17:rangorde 6 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05c0" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05c1 a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05a6> ;
+    ns17:rangorde 7 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05c1" ;
+    ns21:title "Vlaams minister van Leefmilieu, Landbouw en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05c2 a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05a8> ;
+    ns17:rangorde 8 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05c2" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05c4 a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c3> ;
+    ns17:rangorde 9 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05c4" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid en E-government" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05c7 a ns17:Mandataris ;
+    ns17:einde "2004-02-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c6> ;
+    ns17:rangorde 10 ;
+    ns17:start "2003-06-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05c7" ;
+    ns21:title "Vlaams minister van Wonen, Media en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05ca a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 1 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05ca" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a05cb a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 2 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05cb" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05cc a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 2 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05cc" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns26:5fed907de6670526694a05cd a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 3 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05cd" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05ce a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 4 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05ce" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Ruimtelijke Ordening, Wetenschappen en Technologische Innovatie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05cf a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 5 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05cf" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Cultuur, Jeugd en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05d0 a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0597> ;
+    ns17:rangorde 6 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05d0" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05d1 a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05a8> ;
+    ns17:rangorde 7 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05d1" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05d2 a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c3> ;
+    ns17:rangorde 8 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05d2" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid en E-government" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05d3 a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c6> ;
+    ns17:rangorde 9 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05d3" ;
+    ns21:title "Vlaams minister van Wonen, Media en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05d5 a ns17:Mandataris ;
+    ns17:einde "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05d4> ;
+    ns17:rangorde 10 ;
+    ns17:start "2004-02-18T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05d5" ;
+    ns21:title "Vlaams minister van Leefmilieu, Landbouw en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05d9 a ns17:Mandataris ;
+    ns17:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 1 ;
+    ns17:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05d9" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:5fed907de6670526694a05da a ns17:Mandataris ;
+    ns17:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 2 ;
+    ns17:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05da" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05db a ns17:Mandataris ;
+    ns17:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 3 ;
+    ns17:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05db" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Ruimtelijke Ordening, Wetenschappen en Technologische Innovatie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05dc a ns17:Mandataris ;
+    ns17:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 4 ;
+    ns17:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05dc" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Cultuur, Jeugd en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05dd a ns17:Mandataris ;
+    ns17:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0597> ;
+    ns17:rangorde 5 ;
+    ns17:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05dd" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05de a ns17:Mandataris ;
+    ns17:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05a8> ;
+    ns17:rangorde 6 ;
+    ns17:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05de" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05df a ns17:Mandataris ;
+    ns17:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c3> ;
+    ns17:rangorde 7 ;
+    ns17:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05df" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid en E-government" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05e0 a ns17:Mandataris ;
+    ns17:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c6> ;
+    ns17:rangorde 8 ;
+    ns17:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05e0" ;
+    ns21:title "Vlaams minister van Wonen, Media en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05e1 a ns17:Mandataris ;
+    ns17:einde "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05d4> ;
+    ns17:rangorde 9 ;
+    ns17:start "2004-07-20T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05e1" ;
+    ns21:title "Vlaams minister van Leefmilieu, Landbouw en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:5fed907de6670526694a05ed a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05ec> ;
+    ns17:rangorde 1 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05ed" ;
+    ns21:title "Vlaams minister van Institutionele Hervormingen, Landbouw, Zeevisserij en Plattelandsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a05f1 a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05ec> ;
+    ns17:rangorde 1 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05f1" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e7> .
+
+ns26:5fed907de6670526694a05f3 a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f2> ;
+    ns17:rangorde 2 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05f3" ;
+    ns21:title "Vlaams minister van Economie, Ondernemen, Wetenschap, Innovatie en Buitenlandse Handel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a05f4 a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f2> ;
+    ns17:rangorde 2 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05f4" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907de6670526694a05f6 a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05f6" ;
+    ns21:title " Vlaams minister van Werk, Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a05f8 a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05f8" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907de6670526694a05fa a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f9> ;
+    ns17:rangorde 4 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05fa" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a05fb a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 5 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05fb" ;
+    ns21:title "Vlaams minister van Financiën en Begroting en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a05fc a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 6 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05fc" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Sport en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a05ff a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 7 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a05ff" ;
+    ns21:title "Vlaams minister van Bestuurszaken, Buitenlands Beleid, Media en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0602 a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 8 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0602" ;
+    ns21:title "Vlaams minister van Openbare Werken, Energie, Leefmilieu en Natuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0604 a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c6> ;
+    ns17:rangorde 9 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0604" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Stedenbeleid, Wonen en Inburgering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0609 a ns17:Mandataris ;
+    ns17:einde "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0608> ;
+    ns17:rangorde 10 ;
+    ns17:start "2004-07-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0609" ;
+    ns21:title "Vlaams minister van Mobiliteit, Sociale Economie en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a060d a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a060d" ;
+    ns21:title "Vlaams minister van Institutionele Hervormingen, Havens, Landbouw, Zeevisserij en Plattelandsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a060e a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a060e" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e7> .
+
+ns26:5fed907de6670526694a060f a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f2> ;
+    ns17:rangorde 2 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a060f" ;
+    ns21:title "Vlaams minister van Economie, Ondernemen, Wetenschap, Innovatie en Buitenlandse Handel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0611 a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f2> ;
+    ns17:rangorde 2 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0611" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907de6670526694a0612 a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0612" ;
+    ns21:title " Vlaams minister van Werk, Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0613 a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0613" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907de6670526694a0614 a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 4 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0614" ;
+    ns21:title "Vlaams minister van Financiën en Begroting en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0615 a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 5 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0615" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Sport en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0616 a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 6 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0616" ;
+    ns21:title "Vlaams minister van Bestuurszaken, Buitenlands Beleid, Media en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0617 a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c6> ;
+    ns17:rangorde 7 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0617" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Stedenbeleid, Wonen en Inburgering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0618 a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0608> ;
+    ns17:rangorde 8 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0618" ;
+    ns21:title "Vlaams minister van Mobiliteit, Sociale Economie en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a061a a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0619> ;
+    ns17:rangorde 9 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a061a" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a061c a ns17:Mandataris ;
+    ns17:einde "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 10 ;
+    ns17:start "2007-06-28T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a061c" ;
+    ns21:title "Vlaams minister van Openbare Werken, Energie, Leefmilieu en Natuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a061d a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a061d" ;
+    ns21:title "Vlaams minister van Institutionele Hervormingen, Havens, Landbouw, Zeevisserij en Plattelandsbeleid " ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a061f a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a061f" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e7> .
+
+ns26:5fed907de6670526694a0620 a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 2 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0620" ;
+    ns21:title "Vlaams minister van Financiën, Begroting en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0621 a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 2 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0621" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907de6670526694a0622 a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0622" ;
+    ns21:title " Vlaams minister van Werk, Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0623 a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0623" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907de6670526694a0624 a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 4 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0624" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Sport en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0625 a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 5 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0625" ;
+    ns21:title "Vlaams minister van Bestuurszaken, Buitenlands Beleid, Media en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0626 a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c6> ;
+    ns17:rangorde 6 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0626" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Stedenbeleid, Wonen en Inburgering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0627 a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0608> ;
+    ns17:rangorde 7 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0627" ;
+    ns21:title "Vlaams minister van Mobiliteit, Sociale Economie en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0628 a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0619> ;
+    ns17:rangorde 8 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0628" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0629 a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 9 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0629" ;
+    ns21:title "Vlaams minister van Openbare Werken, Energie, Leefmilieu en Natuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a062a a ns17:Mandataris ;
+    ns17:einde "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c3> ;
+    ns17:rangorde 10 ;
+    ns17:start "2007-10-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a062a" ;
+    ns21:title "Vlaams minister van Economie, Ondernemen, Wetenschap, Innovatie en Buitenlandse Handel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a062b a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a062b" ;
+    ns21:title "Vlaams minister van Institutionele Hervormingen, Bestuurszaken, Buitenlands Beleid, Media, Toerisme, Havens, Landbouw, Zeevisserij en Plattelandsbeleid " ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a062c a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a062c" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e7> .
+
+ns26:5fed907de6670526694a062d a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 2 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a062d" ;
+    ns21:title "Vlaams minister van Financiën en Begroting en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a062e a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 2 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a062e" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907de6670526694a062f a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a062f" ;
+    ns21:title " Vlaams minister van Werk, Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0630 a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0630" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907de6670526694a0631 a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 4 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0631" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Sport en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0632 a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c6> ;
+    ns17:rangorde 5 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0632" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Stedenbeleid, Wonen en Inburgering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0633 a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0608> ;
+    ns17:rangorde 6 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0633" ;
+    ns21:title "Vlaams minister van Mobiliteit, Sociale Economie en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0634 a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0619> ;
+    ns17:rangorde 7 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0634" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0635 a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 8 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0635" ;
+    ns21:title "Vlaams minister van Openbare Werken, Energie, Leefmilieu en Natuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0636 a ns17:Mandataris ;
+    ns17:einde "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c3> ;
+    ns17:rangorde 9 ;
+    ns17:start "2008-09-22T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0636" ;
+    ns21:title "Vlaams minister van Economie, Ondernemen, Wetenschap, Innovatie en Buitenlandse Handel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0637 a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0637" ;
+    ns21:title "Vlaams minister van Institutionele Hervormingen, Bestuurszaken, Buitenlands Beleid, Media, Toerisme, Havens, Landbouw, Zeevisserij en Plattelandsbeleid " ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0638 a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0638" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e7> .
+
+ns26:5fed907de6670526694a0639 a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 2 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0639" ;
+    ns21:title "Vlaams minister van Financiën en Begroting en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a063a a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 2 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a063a" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907de6670526694a063b a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a063b" ;
+    ns21:title " Vlaams minister van Werk, Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a063c a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a063c" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907de6670526694a063d a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 4 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a063d" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Sport en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a063e a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c6> ;
+    ns17:rangorde 5 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a063e" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Stedenbeleid, Wonen en Inburgering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a063f a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0608> ;
+    ns17:rangorde 6 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a063f" ;
+    ns21:title "Vlaams minister van Mobiliteit, Sociale Economie en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0640 a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 7 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0640" ;
+    ns21:title "Vlaams minister van Openbare Werken, Energie, Leefmilieu en Natuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0641 a ns17:Mandataris ;
+    ns17:einde "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c3> ;
+    ns17:rangorde 8 ;
+    ns17:start "2008-12-30T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0641" ;
+    ns21:title "Vlaams minister van Economie, Ondernemen, Wetenschap, Innovatie en Buitenlandse Handel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0642 a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0642" ;
+    ns21:title "Vlaams minister van Institutionele Hervormingen, Bestuurszaken, Buitenlands Beleid, Media, Toerisme, Havens, Landbouw, Zeevisserij en Plattelandsbeleid " ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0643 a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0643" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e7> .
+
+ns26:5fed907de6670526694a0644 a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> ;
+    ns17:rangorde 2 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0644" ;
+    ns21:title "Vlaams minister van Financiën en Begroting en Ruimtelijke Ordening" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907de6670526694a0645 a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907de6670526694a0645" ;
+    ns21:title " Vlaams minister van Werk, Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907ee6670526694a0646 a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> ;
+    ns17:rangorde 3 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0646" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907ee6670526694a0647 a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 4 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0647" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Sport en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907ee6670526694a0648 a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c6> ;
+    ns17:rangorde 5 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0648" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Stedenbeleid, Wonen en Inburgering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907ee6670526694a0649 a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0608> ;
+    ns17:rangorde 6 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0649" ;
+    ns21:title "Vlaams minister van Mobiliteit, Sociale Economie en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907ee6670526694a064a a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 7 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a064a" ;
+    ns21:title "Vlaams minister van Openbare Werken, Energie, Leefmilieu en Natuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907ee6670526694a064b a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c3> ;
+    ns17:rangorde 8 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a064b" ;
+    ns21:title "Vlaams minister van Economie, Ondernemen, Wetenschap, Innovatie en Buitenlandse Handel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907ee6670526694a064c a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c3> ;
+    ns17:rangorde 8 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a064c" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> .
+
+ns26:5fed907ee6670526694a064e a ns17:Mandataris ;
+    ns17:einde "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a064d> ;
+    ns17:rangorde 9 ;
+    ns17:start "2009-01-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a064e" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> .
+
+ns26:5fed907ee6670526694a0659 a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0659" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid, Landbouw en Plattelandsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a065a a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a065a" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0654> .
+
+ns26:5fed907ee6670526694a065c a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a065b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a065c" ;
+    ns21:title "Vlaams minister van Innovatie, Overheidsinvesteringen, Media en Armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a065f a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a065b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a065f" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0655> .
+
+ns26:5fed907ee6670526694a0661 a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 4 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0661" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0662 a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 5 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0662" ;
+    ns21:title "Vlaams minister van Mobiliteit en Openbare Werken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0664 a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0663> ;
+    ns17:rangorde 6 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0664" ;
+    ns21:title "Vlaams minister van Energie, Wonen, Steden en Sociale Economie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0667 a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0666> ;
+    ns17:rangorde 8 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0667" ;
+    ns21:title "Vlaams minister van Leefmilieu, Natuur en Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0669 a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0668> ;
+    ns17:rangorde 9 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0669" ;
+    ns21:title "Vlaams minister van Onderwijs, Jeugd, Gelijke Kansen en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a066a a ns17:Mandataris ;
+    ns17:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a066a" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid, Landbouw en Plattelandsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a066b a ns17:Mandataris ;
+    ns17:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a066b" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0654> .
+
+ns26:5fed907ee6670526694a066c a ns17:Mandataris ;
+    ns17:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a065b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a066c" ;
+    ns21:title "Vlaams minister van Innovatie, Overheidsinvesteringen, Media en Armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a066d a ns17:Mandataris ;
+    ns17:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a065b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a066d" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0655> .
+
+ns26:5fed907ee6670526694a066e a ns17:Mandataris ;
+    ns17:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 3 ;
+    ns17:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a066e" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a066f a ns17:Mandataris ;
+    ns17:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 4 ;
+    ns17:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a066f" ;
+    ns21:title "Vlaams minister van Mobiliteit en Openbare Werken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0670 a ns17:Mandataris ;
+    ns17:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0663> ;
+    ns17:rangorde 5 ;
+    ns17:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0670" ;
+    ns21:title "Vlaams minister van Energie, Wonen, Steden en Sociale Economie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0671 a ns17:Mandataris ;
+    ns17:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0666> ;
+    ns17:rangorde 6 ;
+    ns17:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0671" ;
+    ns21:title "Vlaams minister van Leefmilieu, Natuur en Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0672 a ns17:Mandataris ;
+    ns17:einde "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0668> ;
+    ns17:rangorde 7 ;
+    ns17:start "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0672" ;
+    ns21:title "Vlaams minister van Onderwijs, Jeugd, Gelijke Kansen en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0673 a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0673" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid, Landbouw en Plattelandsbeleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0674 a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> ;
+    ns17:rangorde 1 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0674" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0654> .
+
+ns26:5fed907ee6670526694a0675 a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a065b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0675" ;
+    ns21:title "Vlaams minister van Innovatie, Overheidsinvesteringen, Media en Armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0676 a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a065b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0676" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0655> .
+
+ns26:5fed907ee6670526694a0677 a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 3 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0677" ;
+    ns21:title "Vlaams minister van Bestuurszaken, Binnenlands Bestuur, Inburgering, Toerisme en Vlaamse Rand" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0679 a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 3 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0679" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0655> .
+
+ns26:5fed907ee6670526694a067a a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 4 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a067a" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a067b a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 5 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a067b" ;
+    ns21:title "Vlaams minister van Mobiliteit en Openbare Werken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a067c a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0663> ;
+    ns17:rangorde 6 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a067c" ;
+    ns21:title "Vlaams minister van Energie, Wonen, Steden en Sociale Economie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a067d a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0666> ;
+    ns17:rangorde 7 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a067d" ;
+    ns21:title "Vlaams minister van Leefmilieu, Natuur en Cultuur" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a067e a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0668> ;
+    ns17:rangorde 8 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a067e" ;
+    ns21:title "Vlaams minister van Onderwijs, Jeugd, Gelijke Kansen en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a0680 a ns17:Mandataris ;
+    ns17:einde "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> ;
+    ns17:rangorde 9 ;
+    ns17:start "2010-07-07T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0680" ;
+    ns21:title "Vlaams minister van Financiën, Begroting, Werk, Ruimtelijke Ordening en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:5fed907ee6670526694a068b a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a068b" ;
+    ns21:title "Vlaams minister van Buitenlands Beleid en Onroerend Erfgoed" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a068d a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a068d" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0686> .
+
+ns26:5fed907ee6670526694a068e a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a068e" ;
+    ns21:title "Vlaams minister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a068f a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a068f" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a0691 a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0690> ;
+    ns17:rangorde 3 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0691" ;
+    ns21:title "Vlaams minister van Begroting, Financiën en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a0692 a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0690> ;
+    ns17:rangorde 3 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0692" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a0694 a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 4 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0694" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Inburgering, Wonen, Gelijke Kansen en armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a0696 a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 4 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0696" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a0698 a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 5 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0698" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken, Vlaamse Rand, Toerisme en Dierenwelzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a069a a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 6 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a069a" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a069b a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> ;
+    ns17:rangorde 7 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a069b" ;
+    ns21:title "Vlaams minister van Werk, Economie, Innovatie en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a069c a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0666> ;
+    ns17:rangorde 8 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a069c" ;
+    ns21:title "Vlaams minister van Omgeving, Natuur en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a069f a ns17:Mandataris ;
+    ns17:einde "2016-04-30T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 9 ;
+    ns17:start "2014-07-25T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a069f" ;
+    ns21:title "Vlaams minister van Cultuur, Media, Jeugd en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06a1 a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06a1" ;
+    ns21:title "Vlaams minister van Buitenlands Beleid en Onroerend Erfgoed" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06a2 a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06a2" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0686> .
+
+ns26:5fed907ee6670526694a06a3 a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06a3" ;
+    ns21:title "Vlaams minister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06a4 a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06a4" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06a5 a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 3 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06a5" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Inburgering, Wonen, Gelijke Kansen en armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06a6 a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 3 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06a6" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06a7 a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06a7" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken, Vlaamse Rand, Toerisme en Dierenwelzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06a8 a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 5 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06a8" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06a9 a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> ;
+    ns17:rangorde 6 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06a9" ;
+    ns21:title "Vlaams minister van Werk, Economie, Innovatie en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06aa a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0666> ;
+    ns17:rangorde 7 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06aa" ;
+    ns21:title "Vlaams minister van Omgeving, Natuur en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06ab a ns17:Mandataris ;
+    ns17:einde "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 8 ;
+    ns17:start "2016-04-29T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ab" ;
+    ns21:title "Vlaams minister van Cultuur, Media, Jeugd en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06ac a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ac" ;
+    ns21:title "Vlaams minister van Buitenlands Beleid en Onroerend Erfgoed" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06ad a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ad" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0686> .
+
+ns26:5fed907ee6670526694a06ae a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ae" ;
+    ns21:title "Vlaams minister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06af a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06af" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06b1 a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06b0> ;
+    ns17:rangorde 3 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06b1" ;
+    ns21:title "Vlaams minister van Begroting, Financiën en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06b2 a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06b0> ;
+    ns17:rangorde 3 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06b2" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06b3 a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 4 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06b3" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Inburgering, Wonen, Gelijke Kansen en armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06b4 a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 4 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06b4" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06b5 a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 5 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06b5" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken, Vlaamse Rand, Toerisme en Dierenwelzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06b6 a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 6 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06b6" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06b7 a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> ;
+    ns17:rangorde 7 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06b7" ;
+    ns21:title "Vlaams minister van Werk, Economie, Innovatie en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06b8 a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0666> ;
+    ns17:rangorde 8 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06b8" ;
+    ns21:title "Vlaams minister van Omgeving, Natuur en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06b9 a ns17:Mandataris ;
+    ns17:einde "2019-01-01T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 9 ;
+    ns17:start "2016-05-04T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06b9" ;
+    ns21:title "Vlaams minister van Cultuur, Media, Jeugd en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06ba a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ba" ;
+    ns21:title "Vlaams minister van Buitenlands Beleid en Onroerend Erfgoed" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06bb a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06bb" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0686> .
+
+ns26:5fed907ee6670526694a06bc a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06bc" ;
+    ns21:title "Vlaams minister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06bd a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06bd" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06be a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 3 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06be" ;
+    ns21:title "Vlaams minister van Cultuur, Media, Jeugd en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06bf a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 3 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06bf" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06c0 a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 4 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06c0" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Inburgering, Wonen, Gelijke Kansen en armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06c1 a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 4 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06c1" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06c2 a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 5 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06c2" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken, Vlaamse Rand, Toerisme en Dierenwelzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06c3 a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 6 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06c3" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06c4 a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> ;
+    ns17:rangorde 7 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06c4" ;
+    ns21:title "Vlaams minister van Werk, Economie, Innovatie en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06c5 a ns17:Mandataris ;
+    ns17:einde "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0666> ;
+    ns17:rangorde 8 ;
+    ns17:start "2018-12-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06c5" ;
+    ns21:title "Vlaams minister van Omgeving, Natuur en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06c6 a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06c6" ;
+    ns21:title "Vlaams minister van Buitenlands Beleid en Onroerend Erfgoed" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06c7 a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06c7" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0686> .
+
+ns26:5fed907ee6670526694a06c8 a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06c8" ;
+    ns21:title "Vlaams minister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06c9 a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06c9" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06ca a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 3 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ca" ;
+    ns21:title "Vlaams minister van Cultuur, Media, Jeugd en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06cb a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 3 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06cb" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06cc a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 4 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06cc" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Inburgering, Wonen, Gelijke Kansen en armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06cd a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 4 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06cd" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06ce a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 5 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ce" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken, Vlaamse Rand, Toerisme en Dierenwelzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06cf a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 6 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06cf" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06d0 a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> ;
+    ns17:rangorde 7 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06d0" ;
+    ns21:title "Vlaams minister van Werk, Economie, Innovatie en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06d1 a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0666> ;
+    ns17:rangorde 8 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06d1" ;
+    ns21:title "Vlaams minister van Omgeving, Natuur en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06d3 a ns17:Mandataris ;
+    ns17:einde "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06d2> ;
+    ns17:rangorde 9 ;
+    ns17:start "2019-01-09T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06d3" ;
+    ns21:title "Vlaams minister van Begroting, Financiën en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06d4 a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06d4" ;
+    ns21:title "Vlaams minister van Buitenlands Beleid en Onroerend Erfgoed" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06d5 a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 1 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06d5" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0686> .
+
+ns26:5fed907ee6670526694a06d6 a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06d6" ;
+    ns21:title "Vlaams minister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06d7 a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06d7" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06d8 a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 3 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06d8" ;
+    ns21:title "Vlaams minister van Cultuur, Media, Jeugd en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06d9 a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 3 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06d9" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06da a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 4 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06da" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Inburgering, Wonen, Gelijke Kansen en armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06db a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 4 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06db" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06dc a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 5 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06dc" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken, Vlaamse Rand, Toerisme en Dierenwelzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06dd a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 6 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06dd" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06de a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> ;
+    ns17:rangorde 7 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06de" ;
+    ns21:title "Vlaams minister van Werk, Economie, Innovatie en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06df a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06d2> ;
+    ns17:rangorde 8 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06df" ;
+    ns21:title "Vlaams minister van Begroting, Financiën en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06e1 a ns17:Mandataris ;
+    ns17:einde "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06e0> ;
+    ns17:rangorde 9 ;
+    ns17:start "2019-02-06T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06e1" ;
+    ns21:title "Vlaams minister van Omgeving, Natuur en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06e4 a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 1 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06e4" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Inburgering, Wonen, Gelijke Kansen en Armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06e5 a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 1 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06e5" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0686> .
+
+ns26:5fed907ee6670526694a06e6 a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06e6" ;
+    ns21:title "Vlaams minister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06e7 a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06e7" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06e8 a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 3 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06e8" ;
+    ns21:title "Vlaams minister van Cultuur, Media, Jeugd en Brussel" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06e9 a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 3 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06e9" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06ea a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ea" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken, Vlaamse Rand, Buitenlands Beleid, Onroerend Erfgoed en Dierenwelzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06eb a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06eb" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06ec a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 5 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ec" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06ed a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> ;
+    ns17:rangorde 6 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ed" ;
+    ns21:title "Vlaams minister van Werk, Economie, Innovatie en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06ee a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06d2> ;
+    ns17:rangorde 7 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06ee" ;
+    ns21:title "Vlaams minister van Begroting, Financiën, Energie, " ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06f0 a ns17:Mandataris ;
+    ns17:einde "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06e0> ;
+    ns17:rangorde 8 ;
+    ns17:start "2019-07-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06f0" ;
+    ns21:title "Vlaams minister van Omgeving, Natuur en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06f1 a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 1 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06f1" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Inburgering, Wonen, Gelijke Kansen en Armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06f2 a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> ;
+    ns17:rangorde 1 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06f2" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0686> .
+
+ns26:5fed907ee6670526694a06f3 a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06f3" ;
+    ns21:title "Vlaams minister van Onderwijs" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06f4 a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06f4" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06f5 a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06d2> ;
+    ns17:rangorde 3 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06f5" ;
+    ns21:title "Vlaams minister van Begroting, Financiën, Energie, Cultuur, Media en Jeugd" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06f6 a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06d2> ;
+    ns17:rangorde 3 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06f6" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06f7 a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06f7" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken, Vlaamse Rand, Buitenlands Beleid, Onroerend Erfgoed en Dierenwelzijn" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06f8 a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06f8" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> .
+
+ns26:5fed907ee6670526694a06f9 a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> ;
+    ns17:rangorde 5 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06f9" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid en Gezin" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06fa a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> ;
+    ns17:rangorde 6 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06fa" ;
+    ns21:title "Vlaams minister van Werk, Economie, Innovatie en Sport" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06fb a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> ;
+    ns17:rangorde 7 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06fb" ;
+    ns21:title "Vlaams minister van Brusselse aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a06fc a ns17:Mandataris ;
+    ns17:einde "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06e0> ;
+    ns17:rangorde 8 ;
+    ns17:start "2019-07-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a06fc" ;
+    ns21:title "Vlaams minister van Omgeving, Natuur en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> .
+
+ns26:5fed907ee6670526694a0708 a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0707> ;
+    ns17:rangorde 1 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0708" ;
+    ns21:title "Vlaams minister van Buitenlandse Zaken, Cultuur, ICT en Facilitair Management" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:5fed907ee6670526694a070c a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0707> ;
+    ns17:rangorde 1 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a070c" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0702> .
+
+ns26:5fed907ee6670526694a070d a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a070d" ;
+    ns21:title "Vlaams minister van Economie, Innovatie, Werk, Sociale economie en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:5fed907ee6670526694a070f a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a070f" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns26:5fed907ee6670526694a0710 a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 3 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0710" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Bestuurszaken, Inburgering en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:5fed907ee6670526694a0711 a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 3 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0711" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns26:5fed907ee6670526694a0712 a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0712" ;
+    ns21:title "Vlaams minister van Onderwijs, Sport, Dierenwelzijn en Vlaamse Rand" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:5fed907ee6670526694a0713 a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0713" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns26:5fed907ee6670526694a0715 a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0714> ;
+    ns17:rangorde 5 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0715" ;
+    ns21:title "Vlaams minister van Justitie en Handhaving, Omgeving, Energie en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:5fed907ee6670526694a0719 a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0718> ;
+    ns17:rangorde 6 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a0719" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid, Gezin en Armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:5fed907ee6670526694a071b a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071a> ;
+    ns17:rangorde 7 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a071b" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Wonen en Onroerend Erfgoed" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:5fed907ee6670526694a071c a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06d2> ;
+    ns17:rangorde 8 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a071c" ;
+    ns21:title "Vlaams minister van Mobiliteit en Openbare Werken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:5fed907ee6670526694a071e a ns17:Mandataris ;
+    ns17:einde "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071d> ;
+    ns17:rangorde 9 ;
+    ns17:start "2019-10-02T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "5fed907ee6670526694a071e" ;
+    ns21:title "Vlaams minister van Brussel, Jeugd en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:60f3b4dc-ad5c-4722-9a69-baf991384412 a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 4 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "60f3b4dc-ad5c-4722-9a69-baf991384412" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:74cf5db5-8b6c-442e-baf4-97fbc896f986 a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0718> ;
+    ns17:rangorde 6 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "74cf5db5-8b6c-442e-baf4-97fbc896f986" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid, Gezin en Armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:763a0c72-6bd3-4670-9ff3-6246b58ba5f1 a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0579> ;
+    ns17:rangorde 10 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "763a0c72-6bd3-4670-9ff3-6246b58ba5f1" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:7cad1801-dfd1-44a6-bdfa-5d4e8259d023 a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "7cad1801-dfd1-44a6-bdfa-5d4e8259d023" ;
+    ns21:title "Vlaams minister van Mobiliteit, Openbare Werken en Energie" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:81e6ca1b-97c1-4572-ae79-fba4ccb91e91 a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0707> ;
+    ns17:rangorde 1 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "81e6ca1b-97c1-4572-ae79-fba4ccb91e91" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0702> .
+
+ns26:94e1a665-19ba-4ed8-97ae-a6061e60349d a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> ;
+    ns17:rangorde 4 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "94e1a665-19ba-4ed8-97ae-a6061e60349d" ;
+    ns21:title "Vlaams minister van Cultuur, Jeugd, Sport, Brusselse Aangelegenheden en Ontwikkelingssamenwerking" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:95cfe981-9d27-4f00-8e50-28519f068e23 a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0545> ;
+    ns17:rangorde 6 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "95cfe981-9d27-4f00-8e50-28519f068e23" ;
+    ns21:title "Vlaams minister van Leefmilieu en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:9ce68339-a517-4501-8302-60472167a8d4 a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> ;
+    ns17:rangorde 5 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "9ce68339-a517-4501-8302-60472167a8d4" ;
+    ns21:title "Vlaams minister van Werkgelegenheid en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:9daab663-7277-4080-85cb-d768feb5242b a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0545> ;
+    ns17:rangorde 7 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "9daab663-7277-4080-85cb-d768feb5242b" ;
+    ns21:title "Vlaams minister van Leefmilieu en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:9f1a1fd0-d4ef-4456-8d73-508847351f20 a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0539> ;
+    ns17:rangorde 3 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "9f1a1fd0-d4ef-4456-8d73-508847351f20" ;
+    ns21:title "Vlaams minister van Welzijn, Gezondheid en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:a390a4fb-1be7-4128-afd0-e38da7883e5d a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "a390a4fb-1be7-4128-afd0-e38da7883e5d" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns26:b7834d9e-8373-4ec2-a124-2623594c772a a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> ;
+    ns17:rangorde 1 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "b7834d9e-8373-4ec2-a124-2623594c772a" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> .
+
+ns26:bd63fe69-25df-4b36-a4f0-c7b87157a89b a ns17:Mandataris ;
+    ns17:einde "2010-07-06T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> ;
+    ns17:rangorde 3 ;
+    ns17:start "2009-07-13T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "bd63fe69-25df-4b36-a4f0-c7b87157a89b" ;
+    ns21:title "Vlaams minister van Bestuurszaken, Binnenlands Bestuur, Inburgering, Toerisme en Vlaamse Rand" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> .
+
+ns26:c66e1c4b-e01f-43c5-88e4-36112ba21db5 a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0587> ;
+    ns17:rangorde 10 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "c66e1c4b-e01f-43c5-88e4-36112ba21db5" ;
+    ns21:title "Vlaams minister van Sport en Hoofdstedelijke Aangelegenheden" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:c88ce55a-a1f8-4d99-b2a8-fff46f62e4e4 a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0579> ;
+    ns17:rangorde 9 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "c88ce55a-a1f8-4d99-b2a8-fff46f62e4e4" ;
+    ns21:title "Vlaams minister van Economie, Buitenlands Beleid, Buitenlandse Handel en Huisvesting" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:cabd47da-7956-4c21-83b3-539fd0f4a4de a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "cabd47da-7956-4c21-83b3-539fd0f4a4de" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns26:cfa50017-b0c5-4638-bb0c-bf486d0dd63b a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 9 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "cfa50017-b0c5-4638-bb0c-bf486d0dd63b" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Ambtenarenzaken en Buitenlands Beleid" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:d437d986-09de-4b46-8fce-f6ca4389f492 a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "d437d986-09de-4b46-8fce-f6ca4389f492" ;
+    ns21:title "Vlaams minister van Onderwijs, Sport, Dierenwelzijn en Vlaamse Rand" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:d52fcc41-d25f-451b-be35-102f650517ab a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> ;
+    ns17:rangorde 5 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "d52fcc41-d25f-451b-be35-102f650517ab" ;
+    ns21:title "Vlaams minister van Onderwijs en Vorming" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:d89222e1-eb8a-411f-8889-b1c1b688ab90 a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071d> ;
+    ns17:rangorde 9 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "d89222e1-eb8a-411f-8889-b1c1b688ab90" ;
+    ns21:title "Vlaams minister van Brussel, Jeugd en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:dc380cfb-3987-42bb-afc6-8e079e64ff63 a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071a> ;
+    ns17:rangorde 7 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "dc380cfb-3987-42bb-afc6-8e079e64ff63" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Wonen en Onroerend Erfgoed" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:dc66d32b-be05-43b8-ac18-0d91fdf8c6ec a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "dc66d32b-be05-43b8-ac18-0d91fdf8c6ec" ;
+    ns21:title "Vlaams minister van Economie, Innovatie, Werk, Sociale economie en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns26:e2242233-4b72-4079-bb20-d196da78edbb a ns17:Mandataris ;
+    ns17:einde "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 3 ;
+    ns17:start "2021-05-10T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "e2242233-4b72-4079-bb20-d196da78edbb" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns26:e86d0c8a-6182-4f73-b921-4a67771a18e0 a ns17:Mandataris ;
+    ns17:einde "2003-03-19T00:00:00+01:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> ;
+    ns17:rangorde 8 ;
+    ns17:start "2003-01-31T00:00:00+01:00"^^xsd:dateTime ;
+    ns3:uuid "e86d0c8a-6182-4f73-b921-4a67771a18e0" ;
+    ns21:title "Vlaams minister van Binnenlandse Aangelegenheden, Cultuur, Jeugd en Ambtenarenzaken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> .
+
+ns26:ed9edaf1-18b5-41ee-ab65-21c70fac2a8b a ns17:Mandataris ;
+    ns17:einde "2001-08-01T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> ;
+    ns17:rangorde 2 ;
+    ns17:start "2001-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "ed9edaf1-18b5-41ee-ab65-21c70fac2a8b" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> .
+
+ns27:145bafde-10ea-4a73-8fe9-042cdea3ccbe a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06d2> ;
+    ns17:rangorde 7 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "145bafde-10ea-4a73-8fe9-042cdea3ccbe" ;
+    ns21:title "Vlaams minister van Mobiliteit en Openbare Werken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:14d57d14-5922-4a7b-8574-1b682df71145 a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "14d57d14-5922-4a7b-8574-1b682df71145" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns27:1c62a2f3-cc0c-4760-ada9-90c7f879369e a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "1c62a2f3-cc0c-4760-ada9-90c7f879369e" ;
+    ns21:title "Vlaams minister van Economie, Innovatie, Werk, Sociale economie en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:34405d19-996f-4f9e-8616-a30e6f3a1175 a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0714> ;
+    ns17:rangorde 5 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "34405d19-996f-4f9e-8616-a30e6f3a1175" ;
+    ns21:title "Vlaams minister van Justitie en Handhaving, Omgeving, Energie en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:38e5e0e9-52c7-4f7d-b92b-16eee0edd193 a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 3 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "38e5e0e9-52c7-4f7d-b92b-16eee0edd193" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Bestuurszaken, Inburgering en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:43c129cc-ba12-4457-b93e-737b7370c46e a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0707> ;
+    ns17:rangorde 1 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "43c129cc-ba12-4457-b93e-737b7370c46e" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0702> .
+
+ns27:488d5ce1-bed5-400c-985a-734ff6e296f5 a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 3 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "488d5ce1-bed5-400c-985a-734ff6e296f5" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns27:4eae2f7e-ca9f-42d6-abed-dcd4ab56fd65 a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071a> ;
+    ns17:rangorde 6 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "4eae2f7e-ca9f-42d6-abed-dcd4ab56fd65" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Wonen en Onroerend Erfgoed" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:6ace9621-2236-4023-b77d-f4cb8dec1565 a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071a> ;
+    ns17:rangorde 6 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "6ace9621-2236-4023-b77d-f4cb8dec1565" ;
+    ns21:title "Vlaams minister van Financiën en Begroting, Wonen en Onroerend Erfgoed" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:758e0782-fa7e-4740-a5fa-032e4c0d04ca a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06d2> ;
+    ns17:rangorde 7 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "758e0782-fa7e-4740-a5fa-032e4c0d04ca" ;
+    ns21:title "Vlaams minister van Mobiliteit en Openbare Werken" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:7c4c08aa-b058-4656-8aac-cd9946cbeac3 a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "7c4c08aa-b058-4656-8aac-cd9946cbeac3" ;
+    ns21:title "Vlaams minister van Onderwijs, Sport, Dierenwelzijn en Vlaamse Rand" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:8d2639a1-afca-467c-b7a8-9ba01fa54852 a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 3 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "8d2639a1-afca-467c-b7a8-9ba01fa54852" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns27:8dcdc330-348d-4f69-b10c-02f584adb9af a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071d> ;
+    ns17:rangorde 8 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "8dcdc330-348d-4f69-b10c-02f584adb9af" ;
+    ns21:title "Vlaams minister van Brussel, Jeugd, Media en Armoedebestrijding" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:a55415f4-a212-4ff0-b8e6-3bc1799361af a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0707> ;
+    ns17:rangorde 1 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "a55415f4-a212-4ff0-b8e6-3bc1799361af" ;
+    ns21:title "Vlaams minister van Buitenlandse Zaken, Cultuur, Digitalisering en Facilitair Management" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:aa642a1e-7cc4-44da-9a6b-bce625761c5f a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0714> ;
+    ns17:rangorde 5 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "aa642a1e-7cc4-44da-9a6b-bce625761c5f" ;
+    ns21:title "Vlaams minister van Justitie en Handhaving, Omgeving, Energie en Toerisme" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:b374d85b-428d-4177-910d-0f7077cb3311 a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0707> ;
+    ns17:rangorde 1 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "b374d85b-428d-4177-910d-0f7077cb3311" ;
+    ns21:title "Minister-president van de Vlaamse Regering" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0702> .
+
+ns27:bb2e174a-374e-447d-ad0c-002204b4561f a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "bb2e174a-374e-447d-ad0c-002204b4561f" ;
+    ns21:title "Vlaams minister van Welzijn, Volksgezondheid, Gezin en Zeevisserij" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:c665812d-820d-4f77-a559-e8c757a82302 a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0707> ;
+    ns17:rangorde 1 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "c665812d-820d-4f77-a559-e8c757a82302" ;
+    ns21:title "Vlaams minister van Buitenlandse Zaken, Cultuur, Digitalisering en Facilitair Management" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:d283fd40-f781-4300-a913-60658e2aec85 a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "d283fd40-f781-4300-a913-60658e2aec85" ;
+    ns21:title "Vlaams minister van Onderwijs, Sport, Dierenwelzijn en Vlaamse Rand" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:d7593ea4-a74d-403d-beeb-8f9ed0fbb082 a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "d7593ea4-a74d-403d-beeb-8f9ed0fbb082" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns27:ddcf86cf-387e-4afc-a38f-2e183ce46909 a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071d> ;
+    ns17:rangorde 8 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "ddcf86cf-387e-4afc-a38f-2e183ce46909" ;
+    ns21:title "Vlaams minister van Brussel, Jeugd en Media" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:e6652d4d-418b-4060-b309-084d6f0a60fe a ns17:Mandataris ;
+    ns17:einde "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> ;
+    ns17:rangorde 3 ;
+    ns17:start "2022-05-16T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "e6652d4d-418b-4060-b309-084d6f0a60fe" ;
+    ns21:title "Vlaams minister van Binnenlands Bestuur, Bestuurszaken, Inburgering en Gelijke Kansen" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns27:e8706d05-70b7-4b5c-ba75-f07c56cb259f a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> ;
+    ns17:rangorde 2 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "e8706d05-70b7-4b5c-ba75-f07c56cb259f" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns27:e92489ff-126c-4569-a15e-ae8e193be345 a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> ;
+    ns17:rangorde 4 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "e92489ff-126c-4569-a15e-ae8e193be345" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> .
+
+ns27:f7fe3320-7c15-4322-b907-02571d3dfe6e a ns17:Mandataris ;
+    ns17:isBestuurlijkeAliasVan <http://themis.vlaanderen.be/id/persoon/74888cf5-6e19-4cf3-abf1-eeb9af999922> ;
+    ns17:rangorde 9 ;
+    ns17:start "2022-05-18T00:00:00+02:00"^^xsd:dateTime ;
+    ns3:uuid "f7fe3320-7c15-4322-b907-02571d3dfe6e" ;
+    ns21:title "Vlaams minister van Economie, Innovatie, Werk, Sociale Economie en Landbouw" ;
+    ns12:holds <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> .
+
+ns25:0a630d03-e849-4ea6-98e1-e041f9098174 a ns22:Invalidation ;
+    ns3:uuid "0a630d03-e849-4ea6-98e1-e041f9098174" ;
+    ns22:atTime "2003-06-04T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:213ac49c-d7af-4444-ad18-a75f9196d3c5 a ns22:Invalidation ;
+    ns3:uuid "213ac49c-d7af-4444-ad18-a75f9196d3c5" ;
+    ns22:atTime "1988-10-22T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:3e2de57a-ad83-4462-8a3f-efb5071af8f9 a ns22:Invalidation ;
+    ns3:uuid "3e2de57a-ad83-4462-8a3f-efb5071af8f9" ;
+    ns22:atTime "2019-07-01T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ce6670526694a041b a ns22:Invalidation ;
+    ns3:uuid "5fed907ce6670526694a041b" ;
+    ns22:atTime "1985-12-10T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ce6670526694a041c a ns22:Invalidation ;
+    ns3:uuid "5fed907ce6670526694a041c" ;
+    ns22:atTime "1985-12-10T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ce6670526694a0445 a ns22:Invalidation ;
+    ns3:uuid "5fed907ce6670526694a0445" ;
+    ns22:atTime "1988-02-02T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ce6670526694a0446 a ns22:Invalidation ;
+    ns3:uuid "5fed907ce6670526694a0446" ;
+    ns22:atTime "1988-02-02T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ce6670526694a0497 a ns22:Invalidation ;
+    ns3:uuid "5fed907ce6670526694a0497" ;
+    ns22:atTime "1992-01-21T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ce6670526694a0498 a ns22:Invalidation ;
+    ns3:uuid "5fed907ce6670526694a0498" ;
+    ns22:atTime "1992-01-21T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907de6670526694a04e7 a ns22:Invalidation ;
+    ns3:uuid "5fed907de6670526694a04e7" ;
+    ns22:atTime "1995-06-19T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907de6670526694a04e8 a ns22:Invalidation ;
+    ns3:uuid "5fed907de6670526694a04e8" ;
+    ns22:atTime "1992-10-19T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907de6670526694a052b a ns22:Invalidation ;
+    ns3:uuid "5fed907de6670526694a052b" ;
+    ns22:atTime "1999-07-12T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907de6670526694a052c a ns22:Invalidation ;
+    ns3:uuid "5fed907de6670526694a052c" ;
+    ns22:atTime "1999-07-12T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907de6670526694a05e3 a ns22:Invalidation ;
+    ns3:uuid "5fed907de6670526694a05e3" ;
+    ns22:atTime "2004-07-21T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907de6670526694a05e4 a ns22:Invalidation ;
+    ns3:uuid "5fed907de6670526694a05e4" ;
+    ns22:atTime "2004-07-21T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ee6670526694a0650 a ns22:Invalidation ;
+    ns3:uuid "5fed907ee6670526694a0650" ;
+    ns22:atTime "2009-07-12T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ee6670526694a0651 a ns22:Invalidation ;
+    ns3:uuid "5fed907ee6670526694a0651" ;
+    ns22:atTime "2009-07-12T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ee6670526694a0682 a ns22:Invalidation ;
+    ns3:uuid "5fed907ee6670526694a0682" ;
+    ns22:atTime "2014-07-24T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ee6670526694a0683 a ns22:Invalidation ;
+    ns3:uuid "5fed907ee6670526694a0683" ;
+    ns22:atTime "2014-07-24T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ee6670526694a06fe a ns22:Invalidation ;
+    ns3:uuid "5fed907ee6670526694a06fe" ;
+    ns22:atTime "2019-10-02T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:5fed907ee6670526694a06ff a ns22:Invalidation ;
+    ns3:uuid "5fed907ee6670526694a06ff" ;
+    ns22:atTime "2019-10-01T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:60d0dc2ab1838d01fca7db6f a ns22:Invalidation ;
+    ns3:uuid "60d0dc2ab1838d01fca7db6f" ;
+    ns22:atTime "1995-06-19T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:65b20fa7-30ea-4d1d-ba3c-8caeca0f4394 a ns22:Invalidation ;
+    ns3:uuid "65b20fa7-30ea-4d1d-ba3c-8caeca0f4394" ;
+    ns22:atTime "2003-06-09T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:a6e42d82-73af-4472-be9c-2295cc2c91d9 a ns22:Invalidation ;
+    ns3:uuid "a6e42d82-73af-4472-be9c-2295cc2c91d9" ;
+    ns22:atTime "2004-07-19T00:00:00+00:00"^^xsd:dateTime .
+
+ns25:dc8685f9-ec92-41ed-9ac5-f4526df96d38 a ns22:Invalidation ;
+    ns3:uuid "dc8685f9-ec92-41ed-9ac5-f4526df96d38" ;
+    ns22:atTime "2007-06-27T00:00:00+00:00"^^xsd:dateTime .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045f> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a045f" ;
+    foaf:familyName "Beysen" ;
+    ns19:gebruikteVoornaam "Edward" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0461> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0461" ;
+    foaf:familyName "Breyne" ;
+    ns19:gebruikteVoornaam "Paul" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0504> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0504" ;
+    foaf:familyName "Van Asbroeck" ;
+    ns19:gebruikteVoornaam "Anne" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f9> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05f9" ;
+    foaf:familyName "Vervotte" ;
+    ns19:gebruikteVoornaam "Inge" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a064d> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a064d" ;
+    foaf:familyName "Heeren" ;
+    ns19:gebruikteVoornaam "Veerle" .
+
+<http://themis.vlaanderen.be/id/persoon/74888cf5-6e19-4cf3-abf1-eeb9af999922> a ns18:Person ;
+    ns3:uuid "74888cf5-6e19-4cf3-abf1-eeb9af999922" ;
+    foaf:familyName "Brouns" ;
+    ns19:gebruikteVoornaam "Jo" .
+
+ns10:60d0dc2ab1838d01fca7db64 a ns11:Bestuurseenheid ;
+    ns3:uuid "60d0dc2ab1838d01fca7db64" ;
+    skos:prefLabel "Vlaamse Gemeenschap" ;
+    ns12:classification ns9:60d0dc2ab1838d01fca7db63 .
+
+ns10:e7a239de-c48c-441c-8293-ec365eedce93 a ns11:Bestuurseenheid ;
+    ns3:uuid "e7a239de-c48c-441c-8293-ec365eedce93" ;
+    skos:prefLabel "Vlaams Gewest" ;
+    ns12:classification ns9:ba6abed5-a5b7-482b-9c19-18d51a4a6e6f .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a03e3> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ce6670526694a03e3" ;
+    skos:prefLabel "Vlaamse Executieve 22/12/1981 - 10/12/1985" ;
+    ns12:hasPost <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e5>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e6>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a041a> ;
+    ns22:qualifiedInvalidation ns25:5fed907ce6670526694a041b ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a041d> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ce6670526694a041d" ;
+    skos:prefLabel "Vlaamse Executieve 11/12/1985 - 02/02/1988" ;
+    ns12:hasPost <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a041f>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0420>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a0444> ;
+    ns22:qualifiedInvalidation ns25:5fed907ce6670526694a0445 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a04e9> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907de6670526694a04e9" ;
+    skos:prefLabel "Vlaamse Regering 20/06/1995 - 12/07/1999" ;
+    ns12:hasPost <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04eb>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ec>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a052a> ;
+    ns22:qualifiedInvalidation ns25:5fed907de6670526694a052b ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0652> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ee6670526694a0652" ;
+    skos:prefLabel "Vlaamse Regering 13/07/2009 - 24/07/2014" ;
+    ns12:hasPost <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0654>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0655>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a0681> ;
+    ns22:qualifiedInvalidation ns25:5fed907ee6670526694a0682 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0700> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ee6670526694a0700" ;
+    skos:prefLabel "Vlaamse Regering 02/10/2019 - ... " ;
+    ns12:hasPost <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0702>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a071f> ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> .
+
+ns1:55c9120c-6a3d-49c4-80c8-ed01e9b92a9b a skos:ConceptScheme ;
+    ns3:uuid "55c9120c-6a3d-49c4-80c8-ed01e9b92a9b" ;
+    skos:prefLabel "Agendapunt types" .
+
+ns1:f27ae84d-fded-4ea5-a8f8-f4b98664214b a skos:ConceptScheme ;
+    ns3:uuid "f27ae84d-fded-4ea5-a8f8-f4b98664214b" ;
+    skos:prefLabel "DCAT distribution types concept scheme" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03f3> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a03f3" ;
+    foaf:familyName "Galle" ;
+    ns19:gebruikteVoornaam "Mark" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03fb> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a03fb" ;
+    foaf:familyName "Schiltz" ;
+    ns19:gebruikteVoornaam "Hugo" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0403> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0403" ;
+    foaf:familyName "Buchmann" ;
+    ns19:gebruikteVoornaam "Jacky" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a042e> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a042e" ;
+    foaf:familyName "Pede" ;
+    ns19:gebruikteVoornaam "Jean" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0433> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0433" ;
+    foaf:familyName "Deprez" ;
+    ns19:gebruikteVoornaam "Paul" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0442> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0442" ;
+    foaf:familyName "Dupré" ;
+    ns19:gebruikteVoornaam "Jos" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05d4> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05d4" ;
+    foaf:familyName "Tavernier" ;
+    ns19:gebruikteVoornaam "Jef" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05ec> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05ec" ;
+    foaf:familyName "Leterme" ;
+    ns19:gebruikteVoornaam "Yves" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0690> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a0690" ;
+    foaf:familyName "Turtelboom" ;
+    ns19:gebruikteVoornaam "Annemie" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06b0> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a06b0" ;
+    foaf:familyName "Tommelein" ;
+    ns19:gebruikteVoornaam "Bart" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0718> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a0718" ;
+    foaf:familyName "Beke" ;
+    ns19:gebruikteVoornaam "Wouter" .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a0447> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ce6670526694a0447" ;
+    skos:prefLabel "Vlaamse Executieve 03/02/1988 - 21/01/1992" ;
+    ns12:hasPost <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0449>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044a>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ce6670526694a0496> ;
+    ns22:qualifiedInvalidation ns25:5fed907ce6670526694a0497 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ce6670526694a0499> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ce6670526694a0499" ;
+    skos:prefLabel "Vlaamse Executieve 22/01/1992 - 19/06/1995" ;
+    ns12:hasPost <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049b>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049c>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d>,
+        <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db68>,
+        <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db69>,
+        <http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a04e6> ;
+    ns22:qualifiedInvalidation ns25:5fed907de6670526694a04e7 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a05e5> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907de6670526694a05e5" ;
+    skos:prefLabel "Vlaamse Regering 22/07/2004 - 12/07/2009" ;
+    ns12:hasPost <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e7>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a064f> ;
+    ns22:qualifiedInvalidation ns25:5fed907ee6670526694a0650 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0684> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907ee6670526694a0684" ;
+    skos:prefLabel "Vlaamse Regering 25/07/2014 - 02/10/2019" ;
+    ns12:hasPost <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0686>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907ee6670526694a06fd> ;
+    ns22:qualifiedInvalidation ns25:5fed907ee6670526694a06fe ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e5> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a03e5" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db65> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e6> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a03e6" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db66> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a041f> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a041f" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db65> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0420> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a0420" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db66> .
+
+<http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db68> a ns17:Mandaat ;
+    ns3:uuid "60d0dc2ab1838d01fca7db68" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db65> .
+
+<http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db69> a ns17:Mandaat ;
+    ns3:uuid "60d0dc2ab1838d01fca7db69" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db66> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03fe> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a03fe" ;
+    foaf:familyName "Akkermans" ;
+    ns19:gebruikteVoornaam "Paul" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0472> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0472" ;
+    foaf:familyName "Coens" ;
+    ns19:gebruikteVoornaam "Daniël" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ab> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a04ab" ;
+    foaf:familyName "Detiège" ;
+    ns19:gebruikteVoornaam "Leona" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0511> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0511" ;
+    foaf:familyName "Grouwels" ;
+    ns19:gebruikteVoornaam "Brigitte" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05a6> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05a6" ;
+    foaf:familyName "Sannen" ;
+    ns19:gebruikteVoornaam "Ludo" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0619> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0619" ;
+    foaf:familyName "Vanackere" ;
+    ns19:gebruikteVoornaam "Steven" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0663> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a0663" ;
+    foaf:familyName "Van den Bossche" ;
+    ns19:gebruikteVoornaam "Freya" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0668> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a0668" ;
+    foaf:familyName "Smet" ;
+    ns19:gebruikteVoornaam "Pascal" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06e0> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a06e0" ;
+    foaf:familyName "Van den Heuvel" ;
+    ns19:gebruikteVoornaam "Koen" .
+
+<http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db65> a ns12:Role ;
+    ns3:uuid "60d0dc2ab1838d01fca7db65" ;
+    skos:inScheme ns24:BestuursfunctieCode ;
+    skos:prefLabel "Voorzitter" .
+
+<http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db66> a ns12:Role ;
+    ns3:uuid "60d0dc2ab1838d01fca7db66" ;
+    skos:inScheme ns24:BestuursfunctieCode ;
+    skos:prefLabel "Vice-voorzitter" .
+
+<http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db67> a ns12:Role ;
+    ns3:uuid "60d0dc2ab1838d01fca7db67" ;
+    skos:inScheme ns24:BestuursfunctieCode ;
+    skos:prefLabel "Gemeenschapsminister" .
+
+ns1:b4470852-7799-42a1-af8f-22d15088ba16 a skos:ConceptScheme ;
+    ns3:uuid "b4470852-7799-42a1-af8f-22d15088ba16" ;
+    skos:prefLabel "Agenda statuses" .
+
+ns1:e93481b2-342d-468b-8def-2d629232d3a5 a skos:ConceptScheme ;
+    ns3:uuid "e93481b2-342d-468b-8def-2d629232d3a5" ;
+    skos:prefLabel "DCAT dataset types concept scheme" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049c> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a049c" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0654> a ns17:Mandaat ;
+    ns3:uuid "5fed907ee6670526694a0654" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ef> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a03ef" ;
+    foaf:familyName "Poma" ;
+    ns19:gebruikteVoornaam "Karel" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03f7> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a03f7" ;
+    foaf:familyName "Steyaert" ;
+    ns19:gebruikteVoornaam "Rika" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04fc> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a04fc" ;
+    foaf:familyName "Baldewijns" ;
+    ns19:gebruikteVoornaam "Eddy" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04fe> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a04fe" ;
+    foaf:familyName "Martens" ;
+    ns19:gebruikteVoornaam "Luc" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0500> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0500" ;
+    foaf:familyName "Van Rompuy" ;
+    ns19:gebruikteVoornaam "Eric" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f2> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05f2" ;
+    foaf:familyName "Moerman" ;
+    ns19:gebruikteVoornaam "Fientje" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0714> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a0714" ;
+    foaf:familyName "Demir" ;
+    ns19:gebruikteVoornaam "Zuhal" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071a> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a071a" ;
+    foaf:familyName "Diependaele" ;
+    ns19:gebruikteVoornaam "Matthias" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a071d> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a071d" ;
+    foaf:familyName "Dalle" ;
+    ns19:gebruikteVoornaam "Benjamin" .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/5fed907de6670526694a052d> a ns11:Bestuursorgaan ;
+    ns3:uuid "5fed907de6670526694a052d" ;
+    skos:prefLabel "Vlaamse Regering 13/07/1999 - 21/07/2004" ;
+    ns12:hasPost <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530>,
+        <http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> ;
+    ns22:qualifiedGeneration <http://themis.vlaanderen.be/id/creatie/5fed907de6670526694a05e2> ;
+    ns22:qualifiedInvalidation ns25:5fed907de6670526694a05e3 ;
+    ns23:isTijdspecialisatieVan <http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> .
+
+ns1:8030c0c4-aff1-4548-92d9-3299ebc43832 a skos:ConceptScheme ;
+    ns3:uuid "8030c0c4-aff1-4548-92d9-3299ebc43832" ;
+    skos:prefLabel "Vergaderactiviteit types" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0449> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a0449" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db65> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044a> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a044a" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db66> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049b> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a049b" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04eb> a ns17:Mandaat ;
+    ns3:uuid "5fed907de6670526694a04eb" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ec> a ns17:Mandaat ;
+    ns3:uuid "5fed907de6670526694a04ec" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0702> a ns17:Mandaat ;
+    ns3:uuid "5fed907ee6670526694a0702" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0406> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0406" ;
+    foaf:familyName "De Wulf" ;
+    ns19:gebruikteVoornaam "Roger" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0587> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0587" ;
+    foaf:familyName "Vanhengel" ;
+    ns19:gebruikteVoornaam "Guy" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05a8> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05a8" ;
+    foaf:familyName "Byttebier" ;
+    ns19:gebruikteVoornaam "Adelheid" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0655> a ns17:Mandaat ;
+    ns3:uuid "5fed907ee6670526694a0655" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a04db> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a04db" ;
+    foaf:familyName "Peeters" ;
+    ns19:gebruikteVoornaam "Leo" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0597> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0597" ;
+    foaf:familyName "Bossuyt" ;
+    ns19:gebruikteVoornaam "Gilbert" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0608> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0608" ;
+    foaf:familyName "Van Brempt" ;
+    ns19:gebruikteVoornaam "Kathleen" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a065b> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a065b" ;
+    foaf:familyName "Lieten" ;
+    ns19:gebruikteVoornaam "Ingrid" .
+
+<http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de> a ns12:Role ;
+    ns3:uuid "5fed907ce6670526694a03de" ;
+    skos:inScheme ns24:BestuursfunctieCode ;
+    skos:prefLabel "Minister-president" .
+
+<http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df> a ns12:Role ;
+    ns3:uuid "5fed907ce6670526694a03df" ;
+    skos:inScheme ns24:BestuursfunctieCode ;
+    skos:prefLabel "Viceminister-president" .
+
+<http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0> a ns12:Role ;
+    ns3:uuid "5fed907ce6670526694a03e0" ;
+    skos:inScheme ns24:BestuursfunctieCode ;
+    skos:prefLabel "Minister" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e7> a ns17:Mandaat ;
+    ns3:uuid "5fed907de6670526694a05e7" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0579> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0579" ;
+    foaf:familyName "Gabriëls" ;
+    ns19:gebruikteVoornaam "Jaak" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0409> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0409" ;
+    foaf:familyName "Lenssens" ;
+    ns19:gebruikteVoornaam "Jan" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0426> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0426" ;
+    foaf:familyName "Waltniel" ;
+    ns19:gebruikteVoornaam "Louis" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c3> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05c3" ;
+    foaf:familyName "Ceysens" ;
+    ns19:gebruikteVoornaam "Patricia" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0666> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a0666" ;
+    foaf:familyName "Schauvliege" ;
+    ns19:gebruikteVoornaam "Joke" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0707> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a0707" ;
+    foaf:familyName "Jambon" ;
+    ns19:gebruikteVoornaam "Jan" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0686> a ns17:Mandaat ;
+    ns3:uuid "5fed907ee6670526694a0686" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0539> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0539" ;
+    foaf:familyName "Vogels" ;
+    ns19:gebruikteVoornaam "Mieke" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0545> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0545" ;
+    foaf:familyName "Dua" ;
+    ns19:gebruikteVoornaam "Vera" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05c6> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05c6" ;
+    foaf:familyName "Keulen" ;
+    ns19:gebruikteVoornaam "Marino" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a06d2> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a06d2" ;
+    foaf:familyName "Peeters" ;
+    ns19:gebruikteVoornaam "Lydia" .
+
+<http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025> a ns11:Bestuursorgaan ;
+    ns11:bestuurt ns10:60d0dc2ab1838d01fca7db64,
+        ns10:e7a239de-c48c-441c-8293-ec365eedce93 ;
+    ns3:uuid "7f2c82aa-75ac-40f8-a6c3-9fe539163025" ;
+    skos:prefLabel "Vlaamse Regering" ;
+    ns12:classification <http://themis.vlaanderen.be/id/concept/bestuursorgaan-classificatie/18893b4f4c664ee182316cca1ecae156>,
+        <http://themis.vlaanderen.be/id/concept/bestuursorgaan-classificatie/9682bad6-9c85-4eeb-9ac1-bba21666469a> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a045c> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a045c" ;
+    foaf:familyName "Weckx" ;
+    ns19:gebruikteVoornaam "Hugo" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0476> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0476" ;
+    foaf:familyName "Sauwens" ;
+    ns19:gebruikteVoornaam "Johan" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04ad> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a04ad" ;
+    foaf:familyName "Demeester-De Meyer" ;
+    ns19:gebruikteVoornaam "Wivina" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a067f> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a067f" ;
+    foaf:familyName "Muyters" ;
+    ns19:gebruikteVoornaam "Philippe" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a056b> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a056b" ;
+    foaf:familyName "Van Grembergen" ;
+    ns19:gebruikteVoornaam "Paul" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05b8> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05b8" ;
+    foaf:familyName "Somers" ;
+    ns19:gebruikteVoornaam "Bart" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0660> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a0660" ;
+    foaf:familyName "Vandeurzen" ;
+    ns19:gebruikteVoornaam "Jo" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a053d> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a053d" ;
+    foaf:familyName "Anciaux" ;
+    ns19:gebruikteVoornaam "Bert" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05f5> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05f5" ;
+    foaf:familyName "Vandenbroucke" ;
+    ns19:gebruikteVoornaam "Frank" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a069e> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a069e" ;
+    foaf:familyName "Gatz" ;
+    ns19:gebruikteVoornaam "Sven" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e8> a ns17:Mandaat ;
+    ns3:uuid "5fed907de6670526694a05e8" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0703> a ns17:Mandaat ;
+    ns3:uuid "5fed907ee6670526694a0703" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a052f> a ns17:Mandaat ;
+    ns3:uuid "5fed907de6670526694a052f" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0530> a ns17:Mandaat ;
+    ns3:uuid "5fed907de6670526694a0530" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0540> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0540" ;
+    foaf:familyName "Vanderpoorten" ;
+    ns19:gebruikteVoornaam "Marleen" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0474> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0474" ;
+    foaf:familyName "Van den Bossche" ;
+    ns19:gebruikteVoornaam "Luc" .
+
+<http://themis.vlaanderen.be/id/mandaat/60d0dc2ab1838d01fca7db6a> a ns17:Mandaat ;
+    ns3:uuid "60d0dc2ab1838d01fca7db6a" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db67> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a03ea> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a03ea" ;
+    foaf:familyName "Geens" ;
+    ns19:gebruikteVoornaam "Gaston" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0430> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0430" ;
+    foaf:familyName "Kelchtermans" ;
+    ns19:gebruikteVoornaam "Theo" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0467> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0467" ;
+    foaf:familyName "De Batselier" ;
+    ns19:gebruikteVoornaam "Norbert" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0693> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a0693" ;
+    foaf:familyName "Homans" ;
+    ns19:gebruikteVoornaam "Liesbeth" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0601> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0601" ;
+    foaf:familyName "Peeters" ;
+    ns19:gebruikteVoornaam "Kris" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0520> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0520" ;
+    foaf:familyName "Stevaert" ;
+    ns19:gebruikteVoornaam "Steve" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0542> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0542" ;
+    foaf:familyName "Landuyt" ;
+    ns19:gebruikteVoornaam "Renaat" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0697> a ns18:Person ;
+    ns3:uuid "5fed907ee6670526694a0697" ;
+    foaf:familyName "Weyts" ;
+    ns19:gebruikteVoornaam "Ben" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a03e7> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a03e7" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db67> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a0421> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a0421" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db67> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a05fe> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a05fe" ;
+    foaf:familyName "Bourgeois" ;
+    ns19:gebruikteVoornaam "Geert" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a04a0> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a04a0" ;
+    foaf:familyName "Van den Brande" ;
+    ns19:gebruikteVoornaam "Luc" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907ce6670526694a0436> a ns18:Person ;
+    ns3:uuid "5fed907ce6670526694a0436" ;
+    foaf:familyName "Dewael" ;
+    ns19:gebruikteVoornaam "Patrick" .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a0549> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a0549" ;
+    foaf:familyName "Van Mechelen" ;
+    ns19:gebruikteVoornaam "Dirk" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0687> a ns17:Mandaat ;
+    ns3:uuid "5fed907ee6670526694a0687" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0656> a ns17:Mandaat ;
+    ns3:uuid "5fed907ee6670526694a0656" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a049d> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a049d" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0> .
+
+<http://themis.vlaanderen.be/id/persoon/5fed907de6670526694a061b> a ns18:Person ;
+    ns3:uuid "5fed907de6670526694a061b" ;
+    foaf:familyName "Crevits" ;
+    ns19:gebruikteVoornaam "Hilde" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0704> a ns17:Mandaat ;
+    ns3:uuid "5fed907ee6670526694a0704" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a04ed> a ns17:Mandaat ;
+    ns3:uuid "5fed907de6670526694a04ed" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ce6670526694a044b> a ns17:Mandaat ;
+    ns3:uuid "5fed907ce6670526694a044b" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/60d0dc2ab1838d01fca7db67> .
+
+ns1:559774e3-061c-4f4b-a758-57228d4b68cd a skos:ConceptScheme ;
+    ns3:uuid "559774e3-061c-4f4b-a758-57228d4b68cd" ;
+    skos:prefLabel "Document types" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a05e9> a ns17:Mandaat ;
+    ns3:uuid "5fed907de6670526694a05e9" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0> .
+
+ns1:459cbdb0-86ff-4106-879c-6aecda7d3dcc a skos:ConceptScheme ;
+    ns3:uuid "459cbdb0-86ff-4106-879c-6aecda7d3dcc" ;
+    skos:prefLabel "Thema's" .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907ee6670526694a0688> a ns17:Mandaat ;
+    ns3:uuid "5fed907ee6670526694a0688" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0> .
+
+<http://themis.vlaanderen.be/id/mandaat/5fed907de6670526694a0531> a ns17:Mandaat ;
+    ns3:uuid "5fed907de6670526694a0531" ;
+    ns12:role <http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0> .
+


### PR DESCRIPTION
This changes the end dates of the mandates to be in line with the spec: https://data.vlaanderen.be/ns/mandaat/#einde
I used this Python script to generate the new dates:
```python
from rdflib import Graph
from rdflib.namespace import XSD
from rdflib.term import URIRef, Literal
import rdflib
import pytz
from datetime import timedelta

brussels_timezone = pytz.timezone('Europe/Brussels')

g = Graph()
new_dates = Graph()

g.parse("/home/kobe/redpencil/kanselarij/app-themis/data/files/57872b85-eb10-4733-8a7f-60f4d787c6fb.ttl", format="ttl")

for subj, pred, obj in g:
    if (
        isinstance(obj, Literal)
        and obj.datatype == XSD.dateTime
        and pred == URIRef("http://data.vlaanderen.be/ns/mandaat#einde")
    ):
        new = obj.value

        # If the end date has no offset, it is created before the specs were followed correctly
        # A day needs to be added to be conform
        if obj.value.tzinfo is None or obj.value.utcoffset() == timedelta(0):
            new += timedelta(days=1)

        new = new.replace(tzinfo=pytz.utc).astimezone(brussels_timezone)
        new = new.replace(hour=0)

        g.remove((subj, pred, obj))
        g.add((subj, pred, Literal(new)))
        new_dates.add((subj, pred, Literal(new)))

    if (
        isinstance(obj, Literal)
        and obj.datatype == XSD.dateTime
        and pred == URIRef("http://data.vlaanderen.be/ns/mandaat#start")
    ):
        new = obj.value
        new = new.replace(tzinfo=pytz.utc).astimezone(brussels_timezone)
        new = new.replace(hour=0)

        g.remove((subj, pred, obj))
        g.add((subj, pred, Literal(new)))
        new_dates.add((subj, pred, Literal(new)))

with open("new_dataset.ttl", "w") as f:
    f.write(g.serialize(format="turtle"))

with open("new_dates.ttl", "w") as f:
    f.write(new_dates.serialize(format="turtle"))
```
