### PR TITLE
chore: change the dispatcher for datasets path to not use cache

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -56,7 +56,7 @@ defmodule Dispatcher do
   end
 
   get "/datasets/*path", %{ layer: :resources, accept: %{ json: true } } do
-    forward conn, path, "http://cache/datasets/"
+    forward conn, path, "http://resource/datasets/"
   end
 
   get "/distributions/*path", %{ layer: :resources, accept: %{ json: true } } do


### PR DESCRIPTION
During the resolving of the themis-valvas timing issue (previous-version of dataset is fetched before the data was copied to the right graph yielding `null`) I hit a cache issue in themis where there was a dataset created but valvas was not consuming it.
Restarting the themis cache fixes it.

So something is wrong with the cache clear-keys for the `datasets` cache. Opting to not have this cached instead. perhaps there is a better solution?