### PR TITLE
determine current gov from dataset - not hardcoded

### DIFF
--- a/scripts/generate-mandatees/config.py
+++ b/scripts/generate-mandatees/config.py
@@ -8,7 +8,7 @@ BRUSSELS_TZ = timezone('Europe/Brussels')
 
 VLAAMSE_REGERING = "http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-40f8-a6c3-9fe539163025"
 
-MP = "https://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de"
+MP = "http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de"
 VICE_MP = "http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df"
 MINISTER = "http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0"
 

--- a/scripts/generate-mandatees/config.py
+++ b/scripts/generate-mandatees/config.py
@@ -11,11 +11,16 @@ VLAAMSE_REGERING = "http://themis.vlaanderen.be/id/bestuursorgaan/7f2c82aa-75ac-
 MP = "http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03de"
 VICE_MP = "http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03df"
 MINISTER = "http://themis.vlaanderen.be/id/bestuursfunctie/5fed907ce6670526694a03e0"
+# These don't exist on themis but are needed for kaleidos. remove from themis migrations after copy
+SECRETARIS = "http://themis.vlaanderen.be/id/bestuursfunctie/9d5ebfb9-3829-4b1f-a2a8-15033f7e2097"
+WAARNEMEND_SECRETARIS = "http://themis.vlaanderen.be/id/bestuursfunctie/cfa6ed74-bb6f-4d4c-b905-9a205be135d7"
 
 BESTUURSFUNCTIES = [
     MP,
     VICE_MP,
-    MINISTER
+    MINISTER,
+    SECRETARIS,
+    WAARNEMEND_SECRETARIS
 ]
 ### CONFIG ###
 

--- a/scripts/generate-mandatees/generate_government_body_top_lvl.py
+++ b/scripts/generate-mandatees/generate_government_body_top_lvl.py
@@ -77,7 +77,7 @@ WHERE {
         BIND(xsd:dateTime(?start_date) AS ?start_datetime)
         BIND(CONCAT(STR(DAY(?start_datetime)), "/", STR(MONTH(?start_datetime)), "/", STR(YEAR(?start_datetime))) AS ?label_start_date)
         BIND($end_datetime AS ?end_datetime)
-        BIND(xsd:date(?end_datetime) AS ?end_date)
+        BIND(xsd:dateTime(?end_datetime) AS ?end_date)
         BIND(CONCAT(STR(DAY(?end_datetime)), "/", STR(MONTH(?end_datetime)), "/", STR(YEAR(?end_datetime))) AS ?label_end_date)
         BIND(CONCAT("Vlaamse Regering ", ?label_start_date, " - ", ?label_end_date) AS ?newLabel)
     }

--- a/scripts/generate-mandatees/legislatuur.py
+++ b/scripts/generate-mandatees/legislatuur.py
@@ -71,7 +71,7 @@ WHERE {
         BIND(xsd:dateTime(?start_date) AS ?start_datetime)
         BIND(CONCAT(STR(DAY(?start_datetime)), "/", STR(MONTH(?start_datetime)), "/", STR(YEAR(?start_datetime))) AS ?label_start_date)
         BIND($end_datetime AS ?end_datetime)
-        BIND(xsd:date(?end_datetime) AS ?end_date)
+        BIND(xsd:dateTime(?end_datetime) AS ?end_date)
         BIND(CONCAT(STR(DAY(?end_datetime)), "/", STR(MONTH(?end_datetime)), "/", STR(YEAR(?end_datetime))) AS ?label_end_date)
         BIND(CONCAT("Vlaamse Regering ", ?label_start_date, " - ", ?label_end_date) AS ?newLabel)
     }

--- a/scripts/generate-mandatees/main.py
+++ b/scripts/generate-mandatees/main.py
@@ -6,13 +6,13 @@ from prompt_toolkit.validation import Validator, ValidationError
 from config import BRUSSELS_TZ, MIGRATIONS_FOLDER
 from mandatees import mandatee_generation_loop
 from duplicate_mandatee import duplicate_mandatees
-from regeringssamenstelling import ask_about_end_regeringssamenstelling, ask_about_start_regeringssamenstelling
+from regeringssamenstelling import ask_about_end_regeringssamenstelling, \
+    ask_about_start_regeringssamenstelling, \
+    ask_about_current_regeringssamenstelling
 from legislatuur import ask_about_end_legislatuur, ask_about_start_legislatuur
 
 THEMIS_GOV_DATASET_MODEL_DOC = "https://themis-test.vlaanderen.be/docs/catalogs"
 THEMIS_GOV_DATASET_MODEL_DOC_SRC = "https://github.com/kanselarij-vlaanderen/frontend-themis/blob/8b288d6af5f67f2ade1ed69f4eeb630d40929105/app/templates/docs/catalogs.hbs#L255"
-
-SAMENSTELLING = "http://themis.vlaanderen.be/id/bestuursorgaan/5fed907ee6670526694a0706" # TODO don't hardcode
 
 END_SAMENSTELLING = 'Een regeringssamenstelling afsluiten'
 END_LEGISLATUUR = 'Een legislatuur afsluiten'
@@ -74,16 +74,16 @@ elif flow_type == START_LEGISLATUUR:
     " Start zo nodig het script opnieuw om een regeringssamenstelling aan te maken.")
 elif flow_type == UPDATE_MANDATEES:
     start_date_default = BRUSSELS_TZ.localize(datetime.datetime(now.year, now.month, now.day))
-    # TODO: ask about samenstelling uri and end_datetime
-    g = duplicate_mandatees(SAMENSTELLING, start_date_default)
-    g = g + mandatee_generation_loop(SAMENSTELLING)
+    samenstelling = ask_about_current_regeringssamenstelling()
+    g = duplicate_mandatees(samenstelling, start_date_default)
+    g = g + mandatee_generation_loop(samenstelling)
     filename_without_ext = MIGRATIONS_FOLDER + "{}-new-minister-data".format(now.strftime("%Y%m%d%H%M%S"))
     filename = '{}.ttl'.format(filename_without_ext)
     g.serialize(destination=filename, format='turtle')
     # TODO: add graph file
 elif flow_type == GEN_MANDATEES:
-    # TODO: ask for samenstelling_uri once, then loop
-    g = mandatee_generation_loop(SAMENSTELLING)
+    samenstelling = ask_about_current_regeringssamenstelling()
+    g = mandatee_generation_loop(samenstelling)
     filename_without_ext = MIGRATIONS_FOLDER + "{}-new-minister-data".format(now.strftime("%Y%m%d%H%M%S"))
     filename = '{}.ttl'.format(filename_without_ext)
     g.serialize(destination=filename, format='turtle')

--- a/scripts/generate-mandatees/regeringssamenstelling.py
+++ b/scripts/generate-mandatees/regeringssamenstelling.py
@@ -62,11 +62,6 @@ WHERE {
 }
 ;
 
-DELETE {
-    GRAPH $graph {
-        ?mandatee mandaat:einde ?mandatee_end .
-    }
-}
 INSERT {
     GRAPH $graph {
         ?mandatee mandaat:einde $end_datetime .
@@ -77,7 +72,7 @@ WHERE {
         $gov_body a besluit:Bestuursorgaan ;
             prov:hadMember ?mandatee .
         ?mandatee a mandaat:Mandataris .
-        OPTIONAL { ?mandatee mandaat:einde ?mandatee_end . }
+        FILTER NOT EXISTS { ?mandatee mandaat:einde ?mandatee_end . }
     }
 }
 """)


### PR DESCRIPTION
It is now more clear to which government you are associating mandatees when creating those.

You will be asked which government ("regeringssamenstelling") you want to associate newly created mandatees to. The current government is provided as a default.

Note that in (the rare, but soon to be) case you just generated a new government without having updated the dump which the script uses, the wrong default will be provided. It should be clear from the printed label that it is wrong though. The default can easily be overridden when prompted in the cli.