### PR TITLE
chore: set ALLOW ORIGIN HEADER on identifier

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     image: semtech/mu-identifier:1.10.1
     environment:
       DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER: '[{"variables":[],"name":"public"},{"variables":[],"name":"clean"}]'
+      DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER: "*"
     restart: always
     logging: *default-logging
   dispatcher:


### PR DESCRIPTION
This makes CORS work when e.g. reaching the SPARQL endpoint from a Yasgui instance (like [the one hosted by redpencil](https://yasgui.tools.redpencil.io/)).

We could also add this header ONLY to the SPARQL endpoint in the dispatcher but I'm not sure that that's valuable (i.e. we're not doing anything wrong by setting it for the whole app, I think).