### PR TITLE
use correct URI base from config for creating mandatees

### DIFF
--- a/scripts/generate-mandatees/config.py
+++ b/scripts/generate-mandatees/config.py
@@ -41,6 +41,7 @@ MIGRATIONS_FOLDER = "/data/app/config/migrations/"
 REGERINGSSAMENSTELLING_BASE_URI = "http://themis.vlaanderen.be/id/bestuursorgaan/"
 LEGISLATUUR_BASE_URI = "http://themis.vlaanderen.be/id/bestuursorgaan/"
 MANDAAT_BASE_URI = "http://themis.vlaanderen.be/id/mandaat/"
+MANDATEE_BASE_URI = "http://themis.vlaanderen.be/id/mandataris/"
 INVALIDATION_BASE_URI = "http://themis.vlaanderen.be/id/opheffing/"
 GENERATION_BASE_URI = "http://themis.vlaanderen.be/id/creatie/"
 

--- a/scripts/generate-mandatees/mandatees.py
+++ b/scripts/generate-mandatees/mandatees.py
@@ -5,7 +5,8 @@ from PyInquirer import prompt
 from rdflib import Graph, Literal, URIRef
 from validation import DateValidator, NumberValidator
 from namespaces import *
-from config import BRUSSELS_TZ
+from config import BRUSSELS_TZ,\
+    MANDATEE_BASE_URI
 
 MANDATEE_QUESTIONS = [
     {
@@ -51,7 +52,7 @@ MANDATEE_QUESTIONS = [
 def generate_mandatee(title, person, start_date, end_date, rank, mandate, regeringssamenstelling):
     g = Graph()
     uuid = generate_uuid()
-    m = g.resource("{}id/mandatee/{}".format(THEMIS_BASE, uuid))
+    m = g.resource(MANDATEE_BASE_URI + Literal(uuid))
     m.set(RDF.type, MANDAAT.Mandataris)
     m.set(MU.uuid, Literal(uuid))
     if title:


### PR DESCRIPTION
Mandatee base URI is inconsistent with what is declared in resources.

the `THEMIS_BASE` from namespaces is no longer in use after this refactor and could be removed

Tested script after change
![Clipboard - October 7, 2024 12_24 PM](https://github.com/user-attachments/assets/383f30fe-6db4-44e4-b682-9cd7bbee37f9)
