### PR TITLE
KAS-5210 add publication-tasks to mu auth config

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -35,7 +35,15 @@ defmodule Acl.UserGroups.Config do
               "http://data.vlaanderen.be/ns/besluit#Vergaderactiviteit",
               "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
               "https://data.vlaanderen.be/ns/dossier#Stuk"
-            ] } } ]
+            ] } },
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/publication-tasks",
+            constraint: %ResourceConstraint{
+              resource_types: [
+                "http://mu.semte.ch/vocabularies/ext/SyncTask",
+                "http://mu.semte.ch/vocabularies/ext/ReleaseTask",
+              ] } }
+        ]
       },
 
       # // CLEANUP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
     labels:
       - "logging=true"
   publication-consumer:
-    image: kanselarij/themis-publication-consumer:2.3.0
+    image: kanselarij/themis-publication-consumer:2.4.0
     environment:
       LOG_SPARQL_ALL: "false"
       DEBUG_AUTH_HEADERS: "false"


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5210

In order to follow up the process between Kaleidos and Themis we need some information about the running tasks.
So we need to be able to query them on a public endpoint.

It will mean that the task data becomes public, but that does not contains any sensitive information.
`SyncTask` and `ReleaseTask` will also get connected to the meeting id with `dct:subject` so we can query which task belongs where. `SyncTask` can have multiple subjects. `ReleaseTask` only 1